### PR TITLE
Version 1.1 - 新增集成基础统计数据

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -80,6 +80,17 @@ func (ctx *ItemContext) GetInt(key string) int {
 	return value.(int)
 }
 
+/*
+* 读取指定key在AppContext中的内容，以int格式输出
+ */
+func (ctx *ItemContext) GetUInt64(key string) uint64 {
+	value, exists := ctx.Get(key)
+	if !exists {
+		return 0
+	}
+	return value.(uint64)
+}
+
 //check exists key
 func (ctx *ItemContext) Exists(key string) bool {
 	_, exists := ctx.contextMap[key]

--- a/core/state.go
+++ b/core/state.go
@@ -1,18 +1,80 @@
 package core
 
 import (
+	"devfeel/framework/json"
+	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
 
 var GlobalState *ServerStateInfo
 
+const (
+	minuteTimeLayout        = "200601021504"
+	dateTimeLayout          = "2006-01-02 15:04:05"
+	defaultReserveMinutes   = 60
+	defaultCheckTimeMinutes = 10
+)
+
 func init() {
 	GlobalState = &ServerStateInfo{
-		ServerStartTime:   time.Now(),
-		TotalRequestCount: 0,
-		TotalErrorCount:   0,
+		ServerStartTime:       time.Now(),
+		TotalRequestCount:     0,
+		TotalErrorCount:       0,
+		IntervalRequestData:   NewItemContext(),
+		DetailRequestPageData: NewItemContext(),
+		IntervalErrorData:     NewItemContext(),
+		DetailErrorPageData:   NewItemContext(),
+		DetailErrorData:       NewItemContext(),
+		DetailHttpCodeData:    NewItemContext(),
+		dataChan_Request:      make(chan *RequestInfo, 1000),
+		dataChan_Error:        make(chan *ErrorInfo, 1000),
+		dataChan_HttpCode:     make(chan *HttpCodeInfo, 1000),
+		infoPool: &pool{
+			requestInfo: sync.Pool{
+				New: func() interface{} {
+					return &RequestInfo{}
+				},
+			},
+			errorInfo: sync.Pool{
+				New: func() interface{} {
+					return &ErrorInfo{}
+				},
+			},
+			httpCodeInfo: sync.Pool{
+				New: func() interface{} {
+					return &HttpCodeInfo{}
+				},
+			},
+		},
 	}
+	go GlobalState.handleInfo()
+	go time.AfterFunc(time.Duration(defaultCheckTimeMinutes)*time.Minute, GlobalState.checkAndRemoveIntervalData)
+}
+
+//pool定义
+type pool struct {
+	requestInfo  sync.Pool
+	errorInfo    sync.Pool
+	httpCodeInfo sync.Pool
+}
+
+type RequestInfo struct {
+	Url string
+	Num uint64
+}
+type ErrorInfo struct {
+	Url    string
+	ErrMsg string
+	Num    uint64
+}
+
+type HttpCodeInfo struct {
+	Url  string
+	Code int
+	Num  uint64
 }
 
 //服务器状态信息
@@ -21,18 +83,218 @@ type ServerStateInfo struct {
 	ServerStartTime time.Time
 	//该运行期间总访问次数
 	TotalRequestCount uint64
-	//该运行期间错误次数
+	//单位时间内请求数据 - 按分钟为单位
+	IntervalRequestData *ItemContext
+	//明细请求页面数据 - 以不带参数的访问url为key
+	DetailRequestPageData *ItemContext
+	//该运行期间异常次数
 	TotalErrorCount uint64
+	//单位时间内异常次数 - 按分钟为单位
+	IntervalErrorData *ItemContext
+	//明细异常页面数据 - 以不带参数的访问url为key
+	DetailErrorPageData *ItemContext
+	//明细异常数据 - 以不带参数的访问url为key
+	DetailErrorData *ItemContext
+	//明细Http状态码数据 - 以HttpCode为key，例如200、500等
+	DetailHttpCodeData *ItemContext
+
+	dataChan_Request  chan *RequestInfo
+	dataChan_Error    chan *ErrorInfo
+	dataChan_HttpCode chan *HttpCodeInfo
+	//对象池
+	infoPool *pool
+}
+
+//ShowHtmlData show server state data html-string format
+func (state *ServerStateInfo) ShowHtmlData() string {
+	data := "<html><body><div>"
+	data += "ServerStartTime : " + state.ServerStartTime.Format(dateTimeLayout)
+	data += "<br>"
+	data += "TotalRequestCount : " + strconv.FormatUint(state.TotalRequestCount, 10)
+	data += "<br>"
+	data += "TotalErrorCount : " + strconv.FormatUint(state.TotalErrorCount, 10)
+	data += "<br>"
+	state.IntervalRequestData.RLock()
+	data += "IntervalRequestData : " + jsonutil.GetJsonString(state.IntervalRequestData.GetCurrentMap())
+	state.IntervalRequestData.RUnlock()
+	data += "<br>"
+	state.DetailRequestPageData.RLock()
+	data += "DetailRequestPageData : " + jsonutil.GetJsonString(state.DetailRequestPageData.GetCurrentMap())
+	state.DetailRequestPageData.RUnlock()
+	data += "<br>"
+	state.IntervalErrorData.RLock()
+	data += "IntervalErrorData : " + jsonutil.GetJsonString(state.IntervalErrorData.GetCurrentMap())
+	state.IntervalErrorData.RUnlock()
+	data += "<br>"
+	state.DetailErrorPageData.RLock()
+	data += "DetailErrorPageData : " + jsonutil.GetJsonString(state.DetailErrorPageData.GetCurrentMap())
+	state.DetailErrorPageData.RUnlock()
+	data += "<br>"
+	state.DetailErrorData.RLock()
+	data += "DetailErrorData : " + jsonutil.GetJsonString(state.DetailErrorData.GetCurrentMap())
+	state.DetailErrorData.RUnlock()
+	data += "<br>"
+	state.DetailHttpCodeData.RLock()
+	data += "DetailHttpCodeData : " + jsonutil.GetJsonString(state.DetailHttpCodeData.GetCurrentMap())
+	state.DetailHttpCodeData.RUnlock()
+	data += "</div></body></html>"
+	return data
+}
+
+//QueryIntervalRequestData query request count by query time
+func (state *ServerStateInfo) QueryIntervalRequestData(queryKey string) uint64 {
+	return state.IntervalRequestData.GetUInt64(queryKey)
+}
+
+//QueryIntervalErrorData query error count by query time
+func (state *ServerStateInfo) QueryIntervalErrorData(queryKey string) uint64 {
+	return state.IntervalErrorData.GetUInt64(queryKey)
 }
 
 //增加请求数
-func (state *ServerStateInfo) AddRequestCount(num uint64) uint64 {
-	atomic.AddUint64(&state.TotalRequestCount, num)
+func (state *ServerStateInfo) AddRequestCount(page string, num uint64) uint64 {
+	if strings.Index(page, "/dotweb/") != 0 {
+		atomic.AddUint64(&state.TotalRequestCount, num)
+		state.addRequestData(page, num)
+	}
 	return state.TotalRequestCount
 }
 
-//增加错误数
-func (state *ServerStateInfo) AddErrorCount(num uint64) uint64 {
-	atomic.AddUint64(&state.TotalErrorCount, num)
+//增加Http状态码数据
+func (state *ServerStateInfo) AddHttpCodeCount(page string, code int, num uint64) uint64 {
+	if strings.Index(page, "/dotweb/") != 0 {
+		state.addHttpCodeData(page, code, num)
+	}
 	return state.TotalErrorCount
+}
+
+//增加错误数
+func (state *ServerStateInfo) AddErrorCount(page string, err error, num uint64) uint64 {
+	atomic.AddUint64(&state.TotalErrorCount, num)
+	state.addErrorData(page, err, num)
+	return state.TotalErrorCount
+}
+
+func (state *ServerStateInfo) addRequestData(page string, num uint64) {
+	//get from pool
+	info := state.infoPool.requestInfo.Get().(*RequestInfo)
+	info.Url = page
+	info.Num = num
+	state.dataChan_Request <- info
+}
+
+func (state *ServerStateInfo) addErrorData(page string, err error, num uint64) {
+	//get from pool
+	info := state.infoPool.errorInfo.Get().(*ErrorInfo)
+	info.Url = page
+	info.ErrMsg = err.Error()
+	info.Num = num
+	state.dataChan_Error <- info
+}
+
+func (state *ServerStateInfo) addHttpCodeData(page string, code int, num uint64) {
+	//get from pool
+	info := state.infoPool.httpCodeInfo.Get().(*HttpCodeInfo)
+	info.Url = page
+	info.Code = code
+	info.Num = num
+	state.dataChan_HttpCode <- info
+}
+
+//处理日志内部函数
+func (state *ServerStateInfo) handleInfo() {
+	for {
+		select {
+		case info := <-state.dataChan_Request:
+			{
+				//set detail page data
+				key := strings.ToLower(info.Url)
+				val := state.DetailRequestPageData.GetUInt64(key)
+				state.DetailRequestPageData.Set(key, val+info.Num)
+
+				//set interval data
+				key = time.Now().Format(minuteTimeLayout)
+				val = state.IntervalRequestData.GetUInt64(key)
+				state.IntervalRequestData.Set(key, val+info.Num)
+
+				//put info obj
+				state.infoPool.requestInfo.Put(info)
+			}
+		case info := <-state.dataChan_Error:
+			{
+				//set detail error page data
+				key := strings.ToLower(info.Url)
+				val := state.DetailErrorPageData.GetUInt64(key)
+				state.DetailErrorPageData.Set(key, val+info.Num)
+
+				//set detail error data
+				key = info.ErrMsg
+				val = state.DetailErrorData.GetUInt64(key)
+				state.DetailErrorData.Set(key, val+info.Num)
+
+				//set interval data
+				key = time.Now().Format(minuteTimeLayout)
+				val = state.IntervalErrorData.GetUInt64(key)
+				state.IntervalErrorData.Set(key, val+info.Num)
+
+				//put info obj
+				state.infoPool.errorInfo.Put(info)
+			}
+		case info := <-state.dataChan_HttpCode:
+			{
+				//set detail error page data
+				key := strconv.Itoa(info.Code)
+				val := state.DetailHttpCodeData.GetUInt64(key)
+				state.DetailHttpCodeData.Set(key, val+info.Num)
+
+				//put info obj
+				state.infoPool.httpCodeInfo.Put(info)
+			}
+		}
+	}
+}
+
+//check and remove need to remove interval data with request and error
+func (state *ServerStateInfo) checkAndRemoveIntervalData() {
+	var needRemoveKey []string
+
+	//check IntervalRequestData
+	state.IntervalRequestData.RLock()
+	if state.IntervalRequestData.Len() > 10 {
+		for k, _ := range state.IntervalRequestData.GetCurrentMap() {
+			if t, err := time.Parse(minuteTimeLayout, k); err != nil {
+				needRemoveKey = append(needRemoveKey, k)
+			} else {
+				if time.Now().Sub(t) > defaultReserveMinutes {
+					needRemoveKey = append(needRemoveKey, k)
+				}
+			}
+		}
+	}
+	state.IntervalRequestData.RUnlock()
+	//remove keys
+	for _, v := range needRemoveKey {
+		state.IntervalRequestData.Remove(v)
+	}
+
+	//check IntervalErrorData
+	needRemoveKey = []string{}
+	state.IntervalErrorData.RLock()
+	if state.IntervalErrorData.Len() > 10 {
+		for k, _ := range state.IntervalErrorData.GetCurrentMap() {
+			if t, err := time.Parse(minuteTimeLayout, k); err != nil {
+				needRemoveKey = append(needRemoveKey, k)
+			} else {
+				if time.Now().Sub(t) > defaultReserveMinutes {
+					needRemoveKey = append(needRemoveKey, k)
+				}
+			}
+		}
+	}
+	//remove keys
+	for _, v := range needRemoveKey {
+		state.IntervalErrorData.Remove(v)
+	}
+
+	time.AfterFunc(time.Duration(defaultCheckTimeMinutes)*time.Minute, state.checkAndRemoveIntervalData)
 }

--- a/core/state.go
+++ b/core/state.go
@@ -28,7 +28,7 @@ func init() {
 		IntervalErrorData:     NewItemContext(),
 		DetailErrorPageData:   NewItemContext(),
 		DetailErrorData:       NewItemContext(),
-		DetailHttpCodeData:    NewItemContext(),
+		DetailHTTPCodeData:    NewItemContext(),
 		dataChan_Request:      make(chan *RequestInfo, 1000),
 		dataChan_Error:        make(chan *ErrorInfo, 1000),
 		dataChan_HttpCode:     make(chan *HttpCodeInfo, 1000),

--- a/core/state.go
+++ b/core/state.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"devfeel/framework/json"
+	"github.com/devfeel/dotweb/framework/json"
 	"strconv"
 	"strings"
 	"sync"

--- a/core/state_test.go
+++ b/core/state_test.go
@@ -1,9 +1,10 @@
 package core
 
 import (
-	"testing"
-	"sync"
+	"errors"
 	"github.com/devfeel/dotweb/test"
+	"sync"
+	"testing"
 )
 
 // 以下为功能测试
@@ -12,18 +13,18 @@ func Test_AddRequestCount_1(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	go addRequestCount(&wg,50)
+	go addRequestCount(&wg, 50)
 
-	go addRequestCount(&wg,60)
+	go addRequestCount(&wg, 60)
 
 	wg.Wait()
 
-	test.Equal(t,uint64(110),GlobalState.TotalRequestCount)
+	test.Equal(t, uint64(110), GlobalState.TotalRequestCount)
 }
 
-func addRequestCount(wg *sync.WaitGroup,count int)  {
+func addRequestCount(wg *sync.WaitGroup, count int) {
 	for i := 0; i < count; i++ {
-		GlobalState.AddRequestCount(1)
+		GlobalState.AddRequestCount("test", 1)
 	}
 	wg.Add(-1)
 }
@@ -32,7 +33,7 @@ func Test_AddRequestCount_2(t *testing.T) {
 	var num uint64 = 1
 	var count uint64
 	for i := 0; i < 100; i++ {
-		count = GlobalState.AddRequestCount(num)
+		count = GlobalState.AddRequestCount("test", num)
 		num++
 	}
 	t.Log("TotalRequestCount:", count)
@@ -42,37 +43,38 @@ func Test_AddErrorCount_1(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	go addErrorCount(&wg,50)
+	go addErrorCount(&wg, 50)
 
-	go addErrorCount(&wg,60)
+	go addErrorCount(&wg, 60)
 
 	wg.Wait()
 
-	test.Equal(t,uint64(110),GlobalState.TotalErrorCount)
+	test.Equal(t, uint64(110), GlobalState.TotalErrorCount)
 }
 
 func Test_AddErrorCount_2(t *testing.T) {
 	var num, count uint64
 	for i := 0; i < 100; i++ {
-		count = GlobalState.AddErrorCount(num)
+		count = GlobalState.AddErrorCount("test", errors.New("test error"), num)
 		num++
 	}
 	t.Log("TotalErrorCount:", count)
 }
 
-func addErrorCount(wg *sync.WaitGroup,count int)  {
+func addErrorCount(wg *sync.WaitGroup, count int) {
 	for i := 0; i < count; i++ {
-		GlobalState.AddErrorCount(1)
+		GlobalState.AddErrorCount("test", errors.New("test error"), 1)
 	}
 	wg.Add(-1)
 }
+
 // 以下是性能测试
 
 //基准测试
 func Benchmark_AddErrorCount_1(b *testing.B) {
 	var num uint64 = 1
 	for i := 0; i < b.N; i++ {
-		GlobalState.AddErrorCount(num)
+		GlobalState.AddErrorCount("test", errors.New("test error"), num)
 	}
 }
 
@@ -81,7 +83,7 @@ func Benchmark_AddErrorCount_Parallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var num uint64 = 1
 		for pb.Next() {
-			GlobalState.AddErrorCount(num)
+			GlobalState.AddErrorCount("test", errors.New("test error"), num)
 		}
 	})
 }
@@ -90,7 +92,7 @@ func Benchmark_AddErrorCount_Parallel(b *testing.B) {
 func Benchmark_AddRequestCount_1(b *testing.B) {
 	var num uint64 = 1
 	for i := 0; i < b.N; i++ {
-		GlobalState.AddRequestCount(num)
+		GlobalState.AddRequestCount("test", num)
 	}
 }
 
@@ -99,7 +101,7 @@ func Benchmark_AddRequestCount_Parallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var num uint64 = 1
 		for pb.Next() {
-			GlobalState.AddRequestCount(num)
+			GlobalState.AddRequestCount("test", num)
 		}
 	})
 }

--- a/dotweb.go
+++ b/dotweb.go
@@ -409,6 +409,7 @@ func initInnerRouter(server *HttpServer) {
 	gInner.GET("/debug/pprof/:key", initPProf)
 	gInner.GET("/debug/freemem", freeMemory)
 	gInner.GET("/state", showServerState)
+	gInner.GET("/state/interval", showIntervalData)
 	gInner.GET("/query/:key", showQuery)
 }
 
@@ -426,9 +427,25 @@ func freeMemory(ctx Context) error {
 	return nil
 }
 
+func showIntervalData(ctx Context) error {
+	type data struct {
+		Time         string
+		RequestCount uint64
+		ErrorCount   uint64
+	}
+	queryKey := ctx.QueryString("querykey")
+
+	d := new(data)
+	d.Time = queryKey
+	d.RequestCount = core.GlobalState.QueryIntervalRequestData(queryKey)
+	d.ErrorCount = core.GlobalState.QueryIntervalErrorData(queryKey)
+	ctx.WriteJson(d)
+	return nil
+}
+
 //显示服务器状态信息
 func showServerState(ctx Context) error {
-	ctx.WriteString(jsonutil.GetJsonString(core.GlobalState))
+	ctx.WriteString(core.GlobalState.ShowHtmlData())
 	return nil
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -31,7 +31,7 @@ func main() {
 	app.SetProductionMode()
 
 	//设置gzip开关
-	app.HttpServer.SetEnabledGzip(true)
+	//app.HttpServer.SetEnabledGzip(true)
 
 	//设置Session开关
 	app.HttpServer.SetEnabledSession(true)
@@ -75,8 +75,9 @@ func main() {
 
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := ctx.WriteStringC(201, "index => ", ctx.RemoteIP(), "我是首页")
-	return err
+	ctx.WriteString(ctx.Request().URL.Path)
+	//_, err := ctx.WriteStringC(201, "index => ", ctx.RemoteIP(), "我是首页")
+	return nil
 }
 
 func IndexReg(ctx dotweb.Context) error {
@@ -126,11 +127,12 @@ func ReturnError(ctx dotweb.Context) error {
 
 func InitRoute(server *dotweb.HttpServer) {
 	server.GET("/", Index)
+	server.GET("/index", Index)
 	server.GET("/id/:id", IndexParam)
 	server.POST("/keypost", KeyPost)
 	server.POST("/jsonpost", JsonPost)
 	server.GET("/error", DefaultError)
 	server.GET("/returnerr", ReturnError)
 	server.GET("/redirect", Redirect)
-	server.Router().RegisterRoute(dotweb.RouteMethod_GET, "/index", IndexReg)
+	//server.Router().RegisterRoute(dotweb.RouteMethod_GET, "/index", IndexReg)
 }

--- a/response.go
+++ b/response.go
@@ -54,6 +54,11 @@ func (r *Response) SetWriter(w http.ResponseWriter) *Response {
 	return r
 }
 
+//HttpCode return http code format int
+func (r *Response) HttpCode() int {
+	return r.Status
+}
+
 func (r *Response) Body() []byte {
 	return r.body
 }

--- a/router.go
+++ b/router.go
@@ -323,7 +323,7 @@ func (r *router) wrapRouterHandle(handler HttpHandle, isHijack bool) RouterHandl
 				}
 
 				//增加错误计数
-				core.GlobalState.AddErrorCount(1)
+				core.GlobalState.AddErrorCount(httpCtx.Request().Path(), fmt.Errorf("%v", err), 1)
 			}
 
 			FeatureTools.ReleaseFeatures(r.server, httpCtx)
@@ -353,7 +353,7 @@ func (r *router) wrapRouterHandle(handler HttpHandle, isHijack bool) RouterHandl
 			if r.server.DotApp.ExceptionHandler != nil {
 				r.server.DotApp.ExceptionHandler(httpCtx, ctxErr)
 				//增加错误计数
-				core.GlobalState.AddErrorCount(1)
+				core.GlobalState.AddErrorCount(httpCtx.Request().Path(), ctxErr, 1)
 			}
 		}
 
@@ -370,7 +370,7 @@ func (r *router) wrapRouterHandle(handler HttpHandle, isHijack bool) RouterHandl
 func (r *router) wrapFileHandle(fileHandler http.Handler) RouterHandle {
 	return func(httpCtx *HttpContext) {
 		//增加状态计数
-		core.GlobalState.AddRequestCount(1)
+		core.GlobalState.AddRequestCount(httpCtx.Request().Path(), 1)
 		startTime := time.Now()
 		httpCtx.Request().URL.Path = httpCtx.RouterParams().ByName("filepath")
 		fileHandler.ServeHTTP(httpCtx.Response().Writer(), httpCtx.Request().Request)
@@ -594,7 +594,7 @@ func (r *router) wrapWebSocketHandle(handler HttpHandle) websocket.Handler {
 				logger.Logger().Log(logString, LogTarget_HttpServer, LogLevel_Error)
 
 				//增加错误计数
-				core.GlobalState.AddErrorCount(1)
+				core.GlobalState.AddErrorCount(httpCtx.Request().Path(), fmt.Errorf("%v", err), 1)
 			}
 			timetaken := int64(time.Now().Sub(startTime) / time.Millisecond)
 			//HttpServer Logging
@@ -611,7 +611,7 @@ func (r *router) wrapWebSocketHandle(handler HttpHandle) websocket.Handler {
 		handler(httpCtx)
 
 		//增加状态计数
-		core.GlobalState.AddRequestCount(1)
+		core.GlobalState.AddRequestCount(httpCtx.Request().Path(), 1)
 	}
 }
 

--- a/router.go
+++ b/router.go
@@ -202,6 +202,9 @@ func (r *router) MatchPath(ctx Context, routePath string) bool {
 
 // ServeHTTP makes the router implement the http.Handler interface.
 func (r *router) ServeHTTP(ctx *HttpContext) {
+	//增加状态计数
+	core.GlobalState.AddRequestCount(ctx.Request().Path(), 1)
+
 	req := ctx.Request().Request
 	w := ctx.Response().Writer()
 	path := req.URL.Path

--- a/server.go
+++ b/server.go
@@ -111,12 +111,9 @@ func (server *HttpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			httpCtx := server.pool.context.Get().(*HttpContext)
 			httpCtx.reset(response, request, server, nil, nil, nil)
 
-			//增加状态计数
-			core.GlobalState.AddRequestCount(httpCtx.Request().Path(), 1)
-
 			server.Router().ServeHTTP(httpCtx)
 
-			core.GlobalState.AddHttpCodeCount(httpCtx.Request().Path(), httpCtx.Response().HttpCode(), 1)
+			core.GlobalState.AddTTPCodeCount(httpCtx.Request().Path(), httpCtx.Response().HttpCode(), 1)
 
 			//release response
 			response.release()

--- a/server.go
+++ b/server.go
@@ -112,9 +112,11 @@ func (server *HttpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			httpCtx.reset(response, request, server, nil, nil, nil)
 
 			//增加状态计数
-			core.GlobalState.AddRequestCount(1)
+			core.GlobalState.AddRequestCount(httpCtx.Request().Path(), 1)
 
 			server.Router().ServeHTTP(httpCtx)
+
+			core.GlobalState.AddHttpCodeCount(httpCtx.Request().Path(), httpCtx.Response().HttpCode(), 1)
 
 			//release response
 			response.release()

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,25 @@
 ## dotweb版本记录：
 
+#### Version 1.1
+* 主要新增集成基础统计数据
+* 【新增】dotweb/state接口，提供基础统计数据，主要数据说明：
+* 1、ServerStartTime 服务启动时间
+* 2、TotalRequestCount 服务启动以来累计请求数（排除了"/dotweb/"下系统自有页面的访问数）
+* 3、TotalErrorCount 服务启动以来累计错误数
+* 4、IntervalRequestData 按1分钟为间隔，默认保存最近60分钟，每分钟的请求数（排除了"/dotweb/"下系统自有页面的访问数）
+* 5、DetailRequestPageData 服务启动以来，每个页面的累计请求数（排除了"/dotweb/"下系统自有页面的访问数）
+* 6、IntervalErrorData 按1分钟为间隔，默认保存最近60分钟，每分钟的错误数
+* 7、DetailErrorPageData 服务启动以来，每个页面的累计错误数
+* 8、DetailErrorData 服务启动以来，每个异常的累计数
+* 9、DetailHttpCodeData 服务启动以来，每个Http状态码的累计数
+* 10、可通过 {host}/dotweb/state 获取数据
+* 【新增】dotweb/state/interval接口，提供按分钟级的基础数据查询
+* 主要数据说明：
+* 1、Time 表示查询时间的字符串，最小单位为分钟，例如：201709251200
+* 2、RequestCount 单位时间内累计请求数（排除了"/dotweb/"下系统自有页面的访问数）
+* 3、ErrorCount 单位时间内累计错误数
+* 2017-09-25 13:00
+
 #### Version 1.0.1
 * 新增logger.SetEnabledConsole，当设置SetDevelopmentMode时自动开启
 * SetEnabledConsole：自动向console输出dotweb基础日志，便于开发人员调试阶段实时查看


### PR DESCRIPTION
* 主要新增集成基础统计数据
* 【新增】dotweb/state接口，提供基础统计数据，主要数据说明：
* 1、ServerStartTime 服务启动时间
* 2、TotalRequestCount 服务启动以来累计请求数（排除了"/dotweb/"下系统自有页面的访问数）
* 3、TotalErrorCount 服务启动以来累计错误数
* 4、IntervalRequestData 按1分钟为间隔，默认保存最近60分钟，每分钟的请求数（排除了"/dotweb/"下系统自有页面的访问数）
* 5、DetailRequestPageData 服务启动以来，每个页面的累计请求数（排除了"/dotweb/"下系统自有页面的访问数）
* 6、IntervalErrorData 按1分钟为间隔，默认保存最近60分钟，每分钟的错误数
* 7、DetailErrorPageData 服务启动以来，每个页面的累计错误数
* 8、DetailErrorData 服务启动以来，每个异常的累计数
* 9、DetailHttpCodeData 服务启动以来，每个Http状态码的累计数
* 10、可通过 {host}/dotweb/state 获取数据
* 【新增】dotweb/state/interval接口，提供按分钟级的基础数据查询
* 主要数据说明：
* 1、Time 表示查询时间的字符串，最小单位为分钟，例如：201709251200
* 2、RequestCount 单位时间内累计请求数（排除了"/dotweb/"下系统自有页面的访问数）
* 3、ErrorCount 单位时间内累计错误数
* 2017-09-25 13:00