### PR TITLE
UPDATE default http port 80 to 8080

### DIFF
--- a/dotweb.go
+++ b/dotweb.go
@@ -50,7 +50,7 @@ type (
 )
 
 const (
-	DefaultHttpPort     = 80 //default http port
+	DefaultHttpPort     = 8080 //default http port
 	RunMode_Development = "development"
 	RunMode_Production  = "production"
 )


### PR DESCRIPTION
UPDATE default http port 80 to 8080
Linux & Mac下80端口开启需要ROOT权限，诸如下面错误。
listen tcp :80: bind: permission denied
一般部署服务器也会使用Nginx做代理。