### PR TITLE
fixed #72 【BUG】app.HttpServer.SetEnabledGzip(true)设置gzip压缩后，访问压缩文件

### DIFF
--- a/context.go
+++ b/context.go
@@ -447,7 +447,7 @@ func (ctx *HttpContext) WriteString(contents ...interface{}) (int, error) {
 // WriteStringC write (httpCode, string, text/plain) to response
 func (ctx *HttpContext) WriteStringC(code int, contents ...interface{}) (int, error) {
 	content := fmt.Sprint(contents...)
-	return ctx.WriteBlobC(code, "", []byte(content))
+	return ctx.WriteBlobC(code, MIMETextPlainCharsetUTF8, []byte(content))
 }
 
 // WriteString write (200, string, text/html) to response


### PR DESCRIPTION
测试了下，仅在WriteString存在。
原因为未显式设置MIME类型导致。、
WriteString默认设置为MIMETextPlainCharsetUTF8
已修复。