### PR TITLE
新增Classic初始化App方式,调整New初始化内容,调整日志启用开关默认为false

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ func NewAccessFmtLog(index string) *AccessFmtLog {
 #### Run Mode
 * 新增development、production模式
 * 默认development，通过DotWeb.SetDevelopmentMode\DotWeb.SetProductionMode开启相关模式
-* 若设置development模式，未处理异常会输出异常详细信息，并且dotweb基础日志会同时向console输出
+* 若设置development模式，未处理异常会输出异常详细信息，同时启用日志开关，同时启用日志console打印
 * 未来会拓展更多运行模式的配置
 
 

--- a/dotweb.go
+++ b/dotweb.go
@@ -54,9 +54,8 @@ const (
 	RunMode_Production  = "production"
 )
 
-/*
-* 创建DotServer实例，返回指针
- */
+
+//New create and return DotApp instance
 func New() *DotWeb {
 	app := &DotWeb{
 		HttpServer:      NewHttpServer(),
@@ -71,10 +70,20 @@ func New() *DotWeb {
 
 	//init logger
 	logger.InitLog()
+	return app
+}
 
+// Classic create and return DotApp instance
+// 1.SetEnabledLog(true)
+// 2.use RequestLog Middleware
+// 3.print logo
+func Classic() *DotWeb {
+	app := New()
+
+	app.SetEnabledLog(true)
+	app.UseRequestLog()
 	//print logo
 	printDotLogo()
-
 	logger.Logger().Debug("DotWeb Start New AppServer", LogTarget_HttpServer)
 	return app
 }
@@ -118,8 +127,11 @@ func (app *DotWeb) IsDevelopmentMode() bool {
 }
 
 // SetDevelopmentMode set run mode on development mode
+// 1.SetEnabledLog(true)
+// 2.SetEnabledConsole(true)
 func (app *DotWeb) SetDevelopmentMode() {
 	app.Config.App.RunMode = RunMode_Development
+	app.SetEnabledLog(true)
 	logger.SetEnabledConsole(true)
 }
 

--- a/example/start/main.go
+++ b/example/start/main.go
@@ -23,7 +23,7 @@ func main(){
 	fmt.Println("dotweb.StartServer error => ", err)
 }
 
-
+// Index index action
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
 	ctx.WriteString(ctx.Request().URL.Path)
@@ -31,7 +31,7 @@ func Index(ctx dotweb.Context) error {
 	return nil
 }
 
-
+// InitRoute init routes
 func InitRoute(server *dotweb.HttpServer) {
 	server.GET("/", Index)
 }

--- a/example/start/main.go
+++ b/example/start/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"github.com/devfeel/dotweb"
+	"fmt"
+	"strconv"
+)
+
+func main(){
+	app := dotweb.Classic()
+	app := dotweb.New()
+	//开启development模式
+	app.SetDevelopmentMode()
+
+	//设置路由
+	InitRoute(app.HttpServer)
+
+
+	// 开始服务
+	port := 8080
+	fmt.Println("dotweb.StartServer => " + strconv.Itoa(port))
+	err := app.StartServer(port)
+	fmt.Println("dotweb.StartServer error => ", err)
+}
+
+
+func Index(ctx dotweb.Context) error {
+	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
+	ctx.WriteString(ctx.Request().URL.Path)
+	//_, err := ctx.WriteStringC(201, "index => ", ctx.RemoteIP(), "我是首页")
+	return nil
+}
+
+
+func InitRoute(server *dotweb.HttpServer) {
+	server.GET("/", Index)
+}

--- a/example/start/main.go
+++ b/example/start/main.go
@@ -8,7 +8,7 @@ import (
 
 func main(){
 	app := dotweb.Classic()
-	app := dotweb.New()
+	//app := dotweb.New()
 	//开启development模式
 	app.SetDevelopmentMode()
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,7 +29,7 @@ type AppLog interface {
 var (
 	appLog         AppLog
 	DefaultLogPath string
-	EnabledLog     bool = true
+	EnabledLog     bool = false
 	EnabledConsole bool = false
 )
 

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,14 @@
 ## dotweb版本记录：
 
+#### Version 1.3.7
+* 新增Classic初始化App方式，调整New初始化内容
+* 调整日志启用开关默认为false，可以通过SetEnabledLog(true)或者SetDevelopmentMode()启用
+* dotweb.New()仅初始化必要的组件，移除打印Logo，移除启动日志
+* dotweb.Classic()方式下，默认启用日志，默认启用RequestLog中间件，默认打印logo以及启动日志
+* dotweb.SetDevelopmentMode()在原有启用屏幕打印的基础上，增加默认开启日志开关
+* 新增 example/start
+* 2017-11-10 21:30
+
 #### Version 1.3.6
 * 升级Redis库，当前版本为redigo V1.2.0
 * 修改Redis工具类中，pool的创建方法由Dial调整为DialUrl


### PR DESCRIPTION
Version 1.3.7
* 新增Classic初始化App方式，调整New初始化内容
* 调整日志启用开关默认为false，可以通过SetEnabledLog(true)或者SetDevelopmentMode()启用
* dotweb.New()仅初始化必要的组件，移除打印Logo，移除启动日志
* dotweb.Classic()方式下，默认启用日志，默认启用RequestLog中间件，默认打印logo以及启动日志
* dotweb.SetDevelopmentMode()在原有启用屏幕打印的基础上，增加默认开启日志开关
* 新增 example/start
* 2017-11-10 21:30