### PR TITLE
Develop - 强化Bind能力,新增PostValues接口,更正Readme部分文字描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ import (
 
 func main() {
     dotapp := dotweb.New()
-    dotapp.HttpServer.GET("/hello", func(ctx *dotweb.HttpContext) {
+    dotapp.HttpServer.GET("/hello", func(ctx dotweb.Context) error{
         ctx.WriteString("hello world!")
+	return nil
     })
     dotapp.StartServer(80)
 }

--- a/README.md
+++ b/README.md
@@ -170,13 +170,14 @@ type UserInfo struct {
 		Sex      int    `form:"sex"`
 }
 
-func(ctx *dotweb.HttpContext) TestBind{
+func TestBind(ctx dotweb.HttpContext) error{
         user := new(UserInfo)
         if err := ctx.Bind(user); err != nil {
         	 ctx.WriteString("err => " + err.Error())
         }else{
              ctx.WriteString("TestBind " + fmt.Sprint(user))
         }
+        return nil
 }
 
 ```
@@ -281,6 +282,9 @@ redis - github.com/garyburd/redigo/redis
 ## 相关项目
 #### <a href="https://github.com/devfeel/tokenserver" target="_blank">TokenServer</a>
 项目简介：token服务，提供token一致性服务以及相关的全局ID生成服务等
+
+#### <a href="https://github.com/devfeel/longweb" target="_blank">LongWeb</a>
+项目简介：http长连接网关服务，提供Websocket及长轮询服务
 
 ## 贡献名单
 目前已经有几位朋友在为框架一起做努力，我们将在合适的时间向大家展现，谢谢他们的支持！

--- a/bind.go
+++ b/bind.go
@@ -17,11 +17,13 @@ type (
 	// Binder is the interface that wraps the Bind method.
 	Binder interface {
 		Bind(interface{}, Context) error
+		BindJsonBody(interface{}, Context) error
 	}
 
 	binder struct{}
 )
 
+//Bind decode req.Body or form-value to struct
 func (b *binder) Bind(i interface{}, ctx Context) (err error) {
 	req := ctx.Request()
 	ctype := req.Header.Get(HeaderContentType)
@@ -47,6 +49,17 @@ func (b *binder) Bind(i interface{}, ctx Context) (err error) {
 		//no check content type for fixed issue #6
 		err = reflects.ConvertMapToStruct(tagName, i, ctx.Request().FormValues())
 	}
+	return err
+}
+
+//BindJsonBody default use json decode req.Body to struct
+func (b *binder) BindJsonBody(i interface{}, ctx Context) (err error) {
+	req := ctx.Request()
+	if req.Body == nil {
+		err = errors.New("request body can't be empty")
+		return err
+	}
+	err = json.NewDecoder(req.Body).Decode(i)
 	return err
 }
 

--- a/context.go
+++ b/context.go
@@ -58,6 +58,7 @@ type (
 		Attachment(file string, name string) error
 		Inline(file string, name string) error
 		Bind(i interface{}) error
+		BindJsonBody(i interface{}) error
 		GetRouterName(key string) string
 		RemoteIP() string
 		SetCookieValue(name, value string, maxAge int)
@@ -379,13 +380,17 @@ func (ctx *HttpContext) contentDisposition(file, name, dispositionType string) (
 	return
 }
 
-/*
-* 支持Json、Xml、Form提交的属性绑定
- */
+// Bind decode req.Body or form-value to struct
 func (ctx *HttpContext) Bind(i interface{}) error {
 	return ctx.httpServer.Binder().Bind(i, ctx)
 }
 
+// BindJsonBody default use json decode req.Body to struct
+func (ctx *HttpContext) BindJsonBody(i interface{}) error {
+	return ctx.httpServer.Binder().BindJsonBody(i, ctx)
+}
+
+// GetRouterName get router name
 func (ctx *HttpContext) GetRouterName(key string) string {
 	return ctx.routerParams.ByName(key)
 }

--- a/example/bind/main.go
+++ b/example/bind/main.go
@@ -73,7 +73,25 @@ func GetBind(ctx dotweb.Context) error {
 	return err
 }
 
+func PostJsonBind(ctx dotweb.Context) error{
+	type UserInfo struct {
+		UserName string `json:"user"`
+		Sex      int    `json:"sex"`
+	}
+	user := new(UserInfo)
+	errstr := "no error"
+	if err := ctx.BindJsonBody(user); err != nil {
+		errstr = err.Error()
+	} else {
+
+	}
+
+	_, err := ctx.WriteString("PostBind [" + errstr + "] " + fmt.Sprint(user))
+	return err
+}
+
 func InitRoute(server *dotweb.HttpServer) {
 	server.Router().POST("/", TestBind)
 	server.Router().GET("/getbind", GetBind)
+	server.Router().POST("/jsonbind", PostJsonBind)
 }

--- a/request.go
+++ b/request.go
@@ -85,10 +85,16 @@ func (req *Request) FormFiles()(map[string]*UploadFile, error){
 	return files, nil
 }
 
-// FormValues 获取包括post、put和get内的值
+// FormValues including both the URL field's query parameters and the POST or PUT form data
 func (req *Request) FormValues() map[string][]string {
 	req.parseForm()
 	return map[string][]string(req.Form)
+}
+
+// PostValues contains the parsed form data from POST, PATCH, or PUT body parameters
+func (req *Request) PostValues() map[string][]string {
+	req.parseForm()
+	return map[string][]string(req.PostForm)
 }
 
 func (req *Request) parseForm() error {

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,16 @@
 ## dotweb版本记录：
 
+#### Version 1.4.0
+* 强化Bind能力，添加BindJsonBody接口，不对Content-Type进行判定，直接获取req.Body进行json序列化
+* 基础Bind机制：
+ 1)如果识别到Content-Type = application/json  会尝试使用json序列化到struct
+ 2)如果识别到Content-Type = application/xml  会尝试使用xml序列化到struct
+ 3)非以上类型，会默认识别form的key/value模式匹配
+* Context.Request()新增PostValues接口，包含 POST, PATCH, or PUT请求集合，以map[string][]string返回
+* 更正Readme部分文字描述
+* 完善example/bind
+* 2017-12-29 16:00:00
+
 #### Version 1.3.9
 * Request新增FormFiles接口，用于支持多文件上传
 * fixed #92 支持多文件同时上传


### PR DESCRIPTION
#### Version 1.4.0
* 强化Bind能力，添加BindJsonBody接口，不对Content-Type进行判定，直接获取req.Body进行json序列化
* 基础Bind机制：
 1)如果识别到Content-Type = application/json  会尝试使用json序列化到struct
 2)如果识别到Content-Type = application/xml  会尝试使用xml序列化到struct
 3)非以上类型，会默认识别form的key/value模式匹配
* Context.Request()新增PostValues接口，包含 POST, PATCH, or PUT请求集合，以map[string][]string返回
* 更正Readme部分文字描述
* 完善example/bind
* 2017-12-29 16:00:00