### PR TITLE
Develop - dotweb新增ExcludeUse接口，重构Middleware实现

### DIFF
--- a/context.go
+++ b/context.go
@@ -87,24 +87,25 @@ type (
 	HttpContext struct {
 		context context.Context
 		//暂未启用
-		cancle       context.CancelFunc
-		request      *Request
-		routerNode   RouterNode
-		routerParams Params
-		response     *Response
-		webSocket    *WebSocket
-		hijackConn   *HijackConn
-		isWebSocket  bool
-		isHijack     bool
-		isEnd        bool //表示当前处理流程是否需要终止
-		httpServer   *HttpServer
-		sessionID    string
-		innerItems   *core.ItemContext
-		items        *core.ItemContext
-		viewData     *core.ItemContext
-		features     *xFeatureTools
-		handler      HttpHandle
-		startTime    time.Time
+		cancle         context.CancelFunc
+		middlewareStep string
+		request        *Request
+		routerNode     RouterNode
+		routerParams   Params
+		response       *Response
+		webSocket      *WebSocket
+		hijackConn     *HijackConn
+		isWebSocket    bool
+		isHijack       bool
+		isEnd          bool //表示当前处理流程是否需要终止
+		httpServer     *HttpServer
+		sessionID      string
+		innerItems     *core.ItemContext
+		items          *core.ItemContext
+		viewData       *core.ItemContext
+		features       *xFeatureTools
+		handler        HttpHandle
+		startTime      time.Time
 	}
 )
 
@@ -129,6 +130,7 @@ func (ctx *HttpContext) reset(res *Response, r *Request, server *HttpServer, nod
 func (ctx *HttpContext) release() {
 	ctx.request = nil
 	ctx.response = nil
+	ctx.middlewareStep = ""
 	ctx.routerNode = nil
 	ctx.routerParams = nil
 	ctx.webSocket = nil

--- a/dotweb.go
+++ b/dotweb.go
@@ -143,11 +143,11 @@ func (app *DotWeb) SetProductionMode() {
 // ExcludeUse registers a middleware exclude routers
 // like exclude /index or /query/:id
 func (app *DotWeb) ExcludeUse(m Middleware, routers ...string) {
-	middlewareLen := len(app.Middlewares) - 1
+	middlewareLen := len(app.Middlewares)
 	if m != nil {
 		m.Exclude(routers...)
-		if middlewareLen >= 0 {
-			app.Middlewares[middlewareLen].SetNext(m)
+		if middlewareLen > 0 {
+			app.Middlewares[middlewareLen-1].SetNext(m)
 		}
 		app.Middlewares = append(app.Middlewares, m)
 	}
@@ -396,7 +396,11 @@ func (app *DotWeb) initBindMiddleware() {
 	for path, node := range router.allNodeMap {
 		logger.Logger().Debug("DotWeb initBindMiddleware "+path+" "+fmt.Sprint(node), LogTarget_HttpServer)
 		node.appMiddlewares = app.Middlewares
-
+		for _, m := range node.appMiddlewares {
+			if m.HasExclude() && m.ExistsExcludeRouter(node.fullPath) {
+				node.hasExcludeMiddleware = true
+			}
+		}
 	}
 }
 

--- a/example/middleware/main.go
+++ b/example/middleware/main.go
@@ -30,9 +30,8 @@ func main() {
 	//app.UseRequestLog()
 	app.Use(
 		NewAccessFmtLog("app"),
-		NewAccessFmtLog("app2"),
-	//NewSimpleAuth("admin"),
 	)
+	app.ExcludeUse(NewAccessFmtLog("appex"), "/", "/")
 
 	//启动 监控服务
 	app.SetPProfConfig(true, 8081)

--- a/example/middleware/main.go
+++ b/example/middleware/main.go
@@ -27,9 +27,10 @@ func main() {
 
 	//InitModule(app)
 
-	app.UseRequestLog()
+	//app.UseRequestLog()
 	app.Use(
 		NewAccessFmtLog("app"),
+		NewAccessFmtLog("app2"),
 	//NewSimpleAuth("admin"),
 	)
 
@@ -51,6 +52,7 @@ func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
 	//fmt.Println(time.Now(), "Index Handler")
 	_, err := ctx.WriteString("index  => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
+	fmt.Println(ctx.RouterNode().GroupMiddlewares())
 	return err
 }
 

--- a/router.go
+++ b/router.go
@@ -491,6 +491,7 @@ func (r *router) add(method, path string, handle RouterHandle, m ...Middleware) 
 	}
 	//fmt.Println("Handle => ", method, " - ", *root, " - ", path)
 	outnode = root.addRoute(path, handle, m...)
+	outnode.fullPath = path
 	r.allNodeMap[method+"_"+path] = outnode
 	return
 }

--- a/router_test.go
+++ b/router_test.go
@@ -60,3 +60,31 @@ func TestLogWebsocketContext(t *testing.T) {
 	//test.NotNil(t,log)
 	test.Equal(t, "", "")
 }
+
+func BenchmarkRouter_MatchPath(b *testing.B) {
+	app := New()
+	server := app.HttpServer
+	r := NewRouter(server)
+	r.GET("/1", func(ctx Context) error {
+		ctx.WriteString("1")
+		return nil
+	})
+	r.GET("/2", func(ctx Context) error {
+		ctx.WriteString("2")
+		return nil
+	})
+	r.POST("/p1", func(ctx Context) error {
+		ctx.WriteString("1")
+		return nil
+	})
+	r.POST("/p2", func(ctx Context) error {
+		ctx.WriteString("2")
+		return nil
+	})
+
+	for i := 0; i < b.N; i++ {
+		if root := r.Nodes["GET"]; root != nil {
+			root.getNode("/1?q=1")
+		}
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -43,15 +43,13 @@ func TestSesionConfig(t *testing.T) {
 	test.Nil(t, sessionManager)
 
 	//switch EnabledSession flag
-	server.SessionConfig.EnabledSession = true
+	server.SessionConfig().EnabledSession = true
 	sessionManager = server.GetSessionManager()
 
 	test.NotNil(t, sessionManager)
 	test.Equal(t, server.sessionManager.CookieName, session.DefaultSessionCookieName)
 	test.Equal(t, server.sessionManager.GCLifetime, int64(session.DefaultSessionGCLifeTime))
 }
-
-
 
 func Index(ctx Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/tree.go
+++ b/tree.go
@@ -41,17 +41,19 @@ const (
 )
 
 type Node struct {
-	path             string
-	wildChild        bool
-	nType            nodeType
-	maxParams        uint8
-	indices          string
-	children         []*Node
-	appMiddlewares   []Middleware
-	groupMiddlewares []Middleware
-	middlewares      []Middleware
-	handle           RouterHandle
-	priority         uint32
+	path                 string
+	fullPath             string
+	hasExcludeMiddleware bool
+	wildChild            bool
+	nType                nodeType
+	maxParams            uint8
+	indices              string
+	children             []*Node
+	appMiddlewares       []Middleware
+	groupMiddlewares     []Middleware
+	middlewares          []Middleware
+	handle               RouterHandle
+	priority             uint32
 }
 
 //Use registers a middleware

--- a/tree.go
+++ b/tree.go
@@ -41,15 +41,17 @@ const (
 )
 
 type Node struct {
-	path        string
-	wildChild   bool
-	nType       nodeType
-	maxParams   uint8
-	indices     string
-	children    []*Node
-	middlewares []Middleware
-	handle      RouterHandle
-	priority    uint32
+	path             string
+	wildChild        bool
+	nType            nodeType
+	maxParams        uint8
+	indices          string
+	children         []*Node
+	appMiddlewares   []Middleware
+	groupMiddlewares []Middleware
+	middlewares      []Middleware
+	handle           RouterHandle
+	priority         uint32
 }
 
 //Use registers a middleware
@@ -68,6 +70,14 @@ func (n *Node) Use(m ...Middleware) *Node {
 		}
 	}
 	return n
+}
+
+func (n *Node) AppMiddlewares() []Middleware {
+	return n.appMiddlewares
+}
+
+func (n *Node) GroupMiddlewares() []Middleware {
+	return n.groupMiddlewares
 }
 
 func (n *Node) Middlewares() []Middleware {

--- a/version.MD
+++ b/version.MD
@@ -2,7 +2,8 @@
 
 #### Version 1.4.1
 * dotweb新增ExcludeUse接口，用于设置指定排除路由的中间件
-* 重构Middleware实现,优化dotweb结构，重构部分内部函数名称
+* 调整dotweb部分内部函数名称
+* 重构Middleware实现,优化代码结构，使流程更清晰
 * Node新增AppMiddlewares与GroupMiddlewares，用于存储App级、Group级的中间件实例
 * Middleware新增Exclude相关接口
 * Exclude(routers ...string)函数，用于指定不生效的路由

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,17 @@
 ## dotweb版本记录：
 
+#### Version 1.4.1
+* 优化dotweb结构，调整部分内部函数名称，增加initBindMiddleware
+* 重构Middleware实现
+* Node新增AppMiddlewares与GroupMiddlewares，用于存储App级、Group级的中间件实例
+* Middleware新增Exclude(routers ...string)函数，用于指定不生效的路由
+* middleware执行优先级：
+- 优先级1：app级别middleware
+- 优先级2：group级别middleware
+- 优先级：router级别middleware
+* 更新example/middleware
+* 2018-01-01 23:00:00
+
 #### Version 1.4.0
 * 强化Bind能力，添加BindJsonBody接口，不对Content-Type进行判定，直接获取req.Body进行json序列化
 * 基础Bind机制：

--- a/version.MD
+++ b/version.MD
@@ -1,10 +1,13 @@
 ## dotweb版本记录：
 
 #### Version 1.4.1
-* 优化dotweb结构，调整部分内部函数名称，增加initBindMiddleware
-* 重构Middleware实现
+* dotweb新增ExcludeUse接口，用于设置指定排除路由的中间件
+* 重构Middleware实现,优化dotweb结构，重构部分内部函数名称
 * Node新增AppMiddlewares与GroupMiddlewares，用于存储App级、Group级的中间件实例
-* Middleware新增Exclude(routers ...string)函数，用于指定不生效的路由
+* Middleware新增Exclude相关接口
+* Exclude(routers ...string)函数，用于指定不生效的路由
+* HasExclude() bool函数，用于判定当前中间件实例是否存在排除路由
+* ExistsExcludeRouter(router string) bool函数，用于判定当前中间件实例的排除路由中是否存在指定路由
 * middleware执行优先级：
 - 优先级1：app级别middleware
 - 优先级2：group级别middleware


### PR DESCRIPTION
#### Version 1.4.1
* dotweb新增ExcludeUse接口，用于设置指定排除路由的中间件
* 调整dotweb部分内部函数名称
* 重构Middleware实现,优化代码结构，使流程更清晰
* Node新增AppMiddlewares与GroupMiddlewares，用于存储App级、Group级的中间件实例
* Middleware新增Exclude相关接口
* Exclude(routers ...string)函数，用于指定不生效的路由
* HasExclude() bool函数，用于判定当前中间件实例是否存在排除路由
* ExistsExcludeRouter(router string) bool函数，用于判定当前中间件实例的排除路由中是否存在指定路由
* middleware执行优先级：
- 优先级1：app级别middleware
- 优先级2：group级别middleware
- 优先级：router级别middleware
* 更新example/middleware
* 2018-01-01 23:00:00