### PR TITLE
Develop - 完善HttpContext，提升易用性

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ func StartServer() error {
 	app.SetLogPath("/home/logs/wwwroot/")
 	//set route
 	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
-		_, err := ctx.WriteString("welcome to my first web!")
-		return err
+		return ctx.WriteString("welcome to my first web!")
 	})
 	//begin server
 	err := app.StartServer(80)
@@ -115,8 +114,7 @@ import (
 func main() {
     dotapp := dotweb.New()
     dotapp.HttpServer.GET("/hello", func(ctx dotweb.Context) error{
-        ctx.WriteString("hello world!")
-	return nil
+        return ctx.WriteString("hello world!")
     })
     dotapp.StartServer(80)
 }
@@ -135,14 +133,12 @@ import (
 func main() {
     dotapp := dotweb.New()
     dotapp.HttpServer.GET("/hello/:name", func(ctx dotweb.Context) error{
-        _, err := ctx.WriteString("hello " + ctx.GetRouterName("name"))
-        return err
+        return ctx.WriteString("hello " + ctx.GetRouterName("name"))
     })
     dotapp.HttpServer.GET("/news/:category/:newsid", func(ctx dotweb.Context) error{
     	category := ctx.GetRouterName("category")
 	    newsid := ctx.GetRouterName("newsid")
-        _, err := ctx.WriteString("news info: category=" + category + " newsid=" + newsid)
-        return err
+        return ctx.WriteString("news info: category=" + category + " newsid=" + newsid)
     })
     dotapp.StartServer(80)
 }
@@ -173,11 +169,10 @@ type UserInfo struct {
 func TestBind(ctx dotweb.HttpContext) error{
         user := new(UserInfo)
         if err := ctx.Bind(user); err != nil {
-        	 ctx.WriteString("err => " + err.Error())
+        	 return ctx.WriteString("err => " + err.Error())
         }else{
-             ctx.WriteString("TestBind " + fmt.Sprint(user))
+             return ctx.WriteString("TestBind " + fmt.Sprint(user))
         }
-        return nil
 }
 
 ```

--- a/example/appcontext/main.go
+++ b/example/appcontext/main.go
@@ -42,8 +42,7 @@ func Index(ctx dotweb.Context) error {
 	gint := ctx.AppContext().GetInt("gint")
 	ctx.AppContext().Set("index", "index-v")
 	ctx.AppContext().Set("user", "user-v")
-	_, err := ctx.WriteString("index -> " + gstring + ";" + strconv.Itoa(gint))
-	return err
+	return ctx.WriteString("index -> " + gstring + ";" + strconv.Itoa(gint))
 }
 
 //you can curl http://127.0.0.1:8080/2
@@ -51,8 +50,7 @@ func Index2(ctx dotweb.Context) error {
 	gindex := ctx.AppContext().GetString("index")
 	ctx.AppContext().Remove("index")
 	user, _ := ctx.AppContext().Once("user")
-	_, err := ctx.WriteString("index -> " + gindex + ";" + fmt.Sprint(user))
-	return err
+	return ctx.WriteString("index -> " + gindex + ";" + fmt.Sprint(user))
 }
 
 func InitRoute(server *dotweb.HttpServer) {

--- a/example/bind/main.go
+++ b/example/bind/main.go
@@ -48,8 +48,7 @@ func TestBind(ctx dotweb.Context) error {
 
 	}
 
-	_, err := ctx.WriteString("TestBind [" + errstr + "] " + fmt.Sprint(user))
-	return err
+	return ctx.WriteString("TestBind [" + errstr + "] " + fmt.Sprint(user))
 }
 
 func GetBind(ctx dotweb.Context) error {
@@ -69,8 +68,7 @@ func GetBind(ctx dotweb.Context) error {
 
 	}
 
-	_, err := ctx.WriteString("GetBind [" + errstr + "] " + fmt.Sprint(user))
-	return err
+	return ctx.WriteString("GetBind [" + errstr + "] " + fmt.Sprint(user))
 }
 
 func PostJsonBind(ctx dotweb.Context) error{
@@ -86,8 +84,7 @@ func PostJsonBind(ctx dotweb.Context) error{
 
 	}
 
-	_, err := ctx.WriteString("PostBind [" + errstr + "] " + fmt.Sprint(user))
-	return err
+	return ctx.WriteString("PostBind [" + errstr + "] " + fmt.Sprint(user))
 }
 
 func InitRoute(server *dotweb.HttpServer) {

--- a/example/cache/main.go
+++ b/example/cache/main.go
@@ -50,8 +50,7 @@ func One(ctx dotweb.Context) error {
 		g = err.Error()
 	}
 	_, err = ctx.Cache().Incr("count")
-	_, err = ctx.WriteString("One [" + g + "] " + fmt.Sprint(err))
-	return err
+	return ctx.WriteString("One [" + g + "] " + fmt.Sprint(err))
 }
 
 func Two(ctx dotweb.Context) error {
@@ -61,8 +60,7 @@ func Two(ctx dotweb.Context) error {
 	}
 	_, err = ctx.Cache().Incr("count")
 	c, _ := ctx.Cache().GetString("count")
-	_, err = ctx.WriteString("Two [" + g + "] [" + c + "] " + fmt.Sprint(err))
-	return err
+	return ctx.WriteString("Two [" + g + "] [" + c + "] " + fmt.Sprint(err))
 }
 
 func InitRoute(server *dotweb.HttpServer) {

--- a/example/config/main.go
+++ b/example/config/main.go
@@ -40,14 +40,12 @@ func main() {
 
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := ctx.WriteString("index => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
-	return err
+	return ctx.WriteString("index => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
 }
 
 func GetAppSet(ctx dotweb.Context) error {
 	key := ctx.QueryString("key")
-	_, err := ctx.WriteString(ctx.Request().Url(), " => key = ", ctx.AppSetConfig().GetString(key))
-	return err
+	return ctx.WriteString(ctx.Request().Url(), " => key = ", ctx.AppSetConfig().GetString(key))
 }
 
 func DefaultPanic(ctx dotweb.Context) error {
@@ -65,13 +63,11 @@ func Redirect(ctx dotweb.Context) error {
 }
 
 func Login(ctx dotweb.Context) error {
-	_, err := ctx.WriteString("login => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
-	return err
+	return ctx.WriteString("login => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
 }
 
 func Logout(ctx dotweb.Context) error {
-	_, err := ctx.WriteString("logout => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
-	return err
+	return ctx.WriteString("logout => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
 }
 
 func RegisterHandler(server *dotweb.HttpServer) {

--- a/example/httpmodule/main.go
+++ b/example/httpmodule/main.go
@@ -54,8 +54,7 @@ func main() {
 func Index(ctx dotweb.Context) error {
 	ctx.Items().Set("count", 2)
 	ctx.WriteString(ctx.Request().Path() + ":Items.Count=> " + ctx.Items().GetString("count"))
-	_, err := ctx.WriteString("\r\n")
-	return err
+	return ctx.WriteString("\r\n")
 }
 
 func WHtml(ctx dotweb.Context) error {

--- a/example/main.go
+++ b/example/main.go
@@ -98,35 +98,30 @@ func Time(ctx dotweb.Context) error {
 
 func IndexReg(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := ctx.WriteString("welcome to dotweb")
-	return err
+	return ctx.WriteString("welcome to dotweb")
 }
 
 func IndexParam(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := ctx.WriteString("IndexParam", ctx.GetRouterName("id"))
-	return err
+	return ctx.WriteString("IndexParam", ctx.GetRouterName("id"))
 }
 
 func KeyPost(ctx dotweb.Context) error {
 	username1 := ctx.PostFormValue("username")
 	username2 := ctx.FormValue("username")
 	username3 := ctx.PostFormValue("username")
-	_, err := ctx.WriteString("username:" + username1 + " - " + username2 + " - " + username3)
-	return err
+	return ctx.WriteString("username:" + username1 + " - " + username2 + " - " + username3)
 }
 
 func JsonPost(ctx dotweb.Context) error {
-	_, err := ctx.WriteString("body:" + string(ctx.Request().PostBody()))
-	return err
+	return ctx.WriteString("body:" + string(ctx.Request().PostBody()))
 }
 
 func DefaultError(ctx dotweb.Context) error {
 	//panic("my panic error!")
 	i := 0
 	b := 2 / i
-	_, err := ctx.WriteString(b)
-	return err
+	return ctx.WriteString(b)
 }
 
 func Redirect(ctx dotweb.Context) error {

--- a/example/middleware/main.go
+++ b/example/middleware/main.go
@@ -50,7 +50,7 @@ func main() {
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
 	//fmt.Println(time.Now(), "Index Handler")
-	_, err := ctx.WriteString("index  => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
+	err := ctx.WriteString("index  => ", fmt.Sprint(ctx.RouterNode().Middlewares()))
 	fmt.Println(ctx.RouterNode().GroupMiddlewares())
 	return err
 }

--- a/example/router/main.go
+++ b/example/router/main.go
@@ -32,14 +32,12 @@ func main() {
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
 	flag := ctx.HttpServer().Router().MatchPath(ctx, "/d/:x/y")
-	_, err := ctx.WriteString("index - " + ctx.Request().Method + " - " + fmt.Sprint(flag))
-	return err
+	return ctx.WriteString("index - " + ctx.Request().Method + " - " + fmt.Sprint(flag))
 }
 
 func Any(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := ctx.WriteString("any - " + ctx.Request().Method)
-	return err
+	return ctx.WriteString("any - " + ctx.Request().Method)
 }
 
 func InitRoute(server *dotweb.HttpServer) {

--- a/example/session/main.go
+++ b/example/session/main.go
@@ -56,7 +56,7 @@ func TestSession(ctx dotweb.Context) error {
 		ctx.WriteString("session read failed, get nil", "\r\n")
 	}
 
-	_, err = ctx.WriteString("userinfo=>" + fmt.Sprintln(userRead))
+	return ctx.WriteString("userinfo=>" + fmt.Sprintln(userRead))
 	return err
 }
 
@@ -73,8 +73,7 @@ func TestReadSession(ctx dotweb.Context) error {
 		ctx.WriteString("session read failed, get nil", "\r\n")
 	}
 
-	_, err := ctx.WriteString("userinfo=>" + fmt.Sprintln(userRead))
-	return err
+	return ctx.WriteString("userinfo=>" + fmt.Sprintln(userRead))
 }
 
 func InitRoute(server *dotweb.HttpServer) {

--- a/example/static/main.go
+++ b/example/static/main.go
@@ -31,8 +31,7 @@ func main() {
 
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, err := ctx.WriteString("index")
-	return err
+	return ctx.WriteString("index")
 }
 
 func InitRoute(server *dotweb.HttpServer) {

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,24 @@
 ## dotweb版本记录：
 
+#### Version 1.4.2
+* Context新增QueryInt\QueryInt64接口，用于简化获取Int类型的Get参数，如果参数未传入或不是合法整形，返回0
+* Context接口调整：除Write外，其他WriteXXX接口，返回值从(int, error)调整为error
+* 带来的变化：
+```
+	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
+		_, err := ctx.WriteString("welcome to my first web!")
+		return err
+	})
+```
+简化为
+```
+	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
+		return ctx.WriteString("welcome to my first web!")
+	})
+```
+* 同步更新example代码
+* 2018-01-03 22:00
+
 #### Version 1.4.1
 * dotweb新增ExcludeUse接口，用于设置指定排除路由的中间件，fixed for #94 建议增加exuse方法用来实现exclude uri功能
 * 调整dotweb部分内部函数名称

--- a/version.MD
+++ b/version.MD
@@ -1,7 +1,7 @@
 ## dotweb版本记录：
 
 #### Version 1.4.1
-* dotweb新增ExcludeUse接口，用于设置指定排除路由的中间件
+* dotweb新增ExcludeUse接口，用于设置指定排除路由的中间件，fixed for #94 建议增加exuse方法用来实现exclude uri功能
 * 调整dotweb部分内部函数名称
 * 重构Middleware实现,优化代码结构，使流程更清晰
 * Node新增AppMiddlewares与GroupMiddlewares，用于存储App级、Group级的中间件实例


### PR DESCRIPTION
#### Version 1.4.2
* Context新增QueryInt\QueryInt64接口，用于简化获取Int类型的Get参数，如果参数未传入或不是合法整形，返回0
* Context接口调整：除Write外，其他WriteXXX接口，返回值从(int, error)调整为error
* 带来的变化：
```
	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
		_, err := ctx.WriteString("welcome to my first web!")
		return err
	})
```
简化为
```
	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
		return ctx.WriteString("welcome to my first web!")
	})
```
* 同步更新example代码
* 2018-01-03 22:00