### PR TITLE
Version 1.4.4 - 调整Bind模块实现，完善日志，增加纯静态文件服务器示例

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -34,9 +34,9 @@ func (b *binder) Bind(i interface{}, ctx Context) (err error) {
 	err = errors.New("request unsupported MediaType -> " + ctype)
 	switch {
 	case strings.HasPrefix(ctype, MIMEApplicationJSON):
-		err = json.NewDecoder(req.Body).Decode(i)
+		err = json.Unmarshal(ctx.Request().PostBody(), i)
 	case strings.HasPrefix(ctype, MIMEApplicationXML):
-		err = xml.NewDecoder(req.Body).Decode(i)
+		err = xml.Unmarshal(ctx.Request().PostBody(), i)
 	//case strings.HasPrefix(ctype, MIMEApplicationForm), strings.HasPrefix(ctype, MIMEMultipartForm),
 	//	strings.HasPrefix(ctype, MIMETextHTML):
 	//	err = reflects.ConvertMapToStruct(defaultTagName, i, ctx.FormValues())
@@ -54,12 +54,11 @@ func (b *binder) Bind(i interface{}, ctx Context) (err error) {
 
 //BindJsonBody default use json decode req.Body to struct
 func (b *binder) BindJsonBody(i interface{}, ctx Context) (err error) {
-	req := ctx.Request()
-	if req.Body == nil {
+	if ctx.Request().PostBody() == nil {
 		err = errors.New("request body can't be empty")
 		return err
 	}
-	err = json.NewDecoder(req.Body).Decode(i)
+	err = json.Unmarshal(ctx.Request().PostBody(), i)
 	return err
 }
 

--- a/example/static/main.go
+++ b/example/static/main.go
@@ -19,22 +19,12 @@ func main() {
 	//设置路由
 	InitRoute(app.HttpServer)
 
-	//启动 监控服务
-	//app.SetPProfConfig(true, 8081)
-
 	// 开始服务
-	port := 8080
+	port := 80
 	fmt.Println("dotweb.StartServer => " + strconv.Itoa(port))
 	err := app.StartServer(port)
 	fmt.Println("dotweb.StartServer error => ", err)
 }
-
-func Index(ctx dotweb.Context) error {
-	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	return ctx.WriteString("index")
-}
-
 func InitRoute(server *dotweb.HttpServer) {
-	server.Router().GET("/", Index)
-	server.Router().ServerFile("/static/*filepath", "d:/gotmp")
+	server.Router().ServerFile("/*filepath", "/devfeel/dotweb/public")
 }

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,11 @@
 ## dotweb版本记录：
 
+#### Version 1.4.4
+* 调整Bind模块内部获取req.Body为HttpContext.PostBody,避免因为Bind后无法再次获取Post内容
+* 完善debug log 输出
+* 更新example/static, 该示例目前为实现一个纯静态文件服务器功能
+* * 2018-01-08 12:00
+
 #### Version 1.4.3
 * 调整dotweb内部路由注册逻辑，New模式默认不开启，Classic模式默认开启，可通过app.UseDotwebRouter手动开启
 * 修复 issue #100, 解决特定场景下Exclude不生效问题


### PR DESCRIPTION
* 调整Bind模块内部获取req.Body为HttpContext.PostBody,避免因为Bind后无法再次获取Post内容
* 完善debug log 输出
* 更新example/static, 该示例目前为实现一个纯静态文件服务器功能
* * 2018-01-08 12:00