### PR TITLE
Version 1.4.6 BUG Fixed & dotweb.Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,14 +272,18 @@ type NotFoundHandle  func(http.ResponseWriter, *http.Request)
 websocket - golang.org/x/net/websocket
 <br>
 redis - github.com/garyburd/redigo/redis
-
+<br>
+yaml - gopkg.in/yaml.v2
 
 ## 相关项目
-#### <a href="https://github.com/devfeel/tokenserver" target="_blank">TokenServer</a>
-项目简介：token服务，提供token一致性服务以及相关的全局ID生成服务等
-
 #### <a href="https://github.com/devfeel/longweb" target="_blank">LongWeb</a>
 项目简介：http长连接网关服务，提供Websocket及长轮询服务
+
+#### <a href="https://github.com/yulibaozi/yulibaozi.com" target="_blank">yulibaozi.com</a>
+项目简介：基于dotweb与mapper的一款go的博客程序
+
+#### <a href="https://github.com/devfeel/tokenserver" target="_blank">TokenServer</a>
+项目简介：token服务，提供token一致性服务以及相关的全局ID生成服务等
 
 ## 贡献名单
 目前已经有几位朋友在为框架一起做努力，我们将在合适的时间向大家展现，谢谢他们的支持！

--- a/consts.go
+++ b/consts.go
@@ -1,5 +1,10 @@
 package dotweb
 
+//dotweb const
+const (
+	Version = "1.4.5.1"
+)
+
 //Log define
 const (
 	LogTarget_Default     = "dotweb_default"

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,11 @@
 ## dotweb版本记录：
 
+#### Version 1.4.6
+* BUG Fixed: UploadFile废弃Bytes接口，新增ReadBytes接口，用于返回上传文件本身
+* 需要特别注意，由于io.read具有一次性特性，UploadFile.SaveFile与UploadFile.ReadBytes只能使用其中一个，另外一个将无法正常获取数据
+* 增加dotweb.Version，用于输出框架版本号
+* 2018-01-21 09:00
+
 #### Version 1.4.5
 * 新增yaml格式配置文件支持，具体参考 example/config/dotweb.yaml
 * config新增UnmarshalYaml\MarshalYaml\MarshalYamlString，提供针对Yaml的常规处理


### PR DESCRIPTION
* BUG Fixed: UploadFile废弃Bytes接口，新增ReadBytes接口，用于返回上传文件本身
* 需要特别注意，由于io.read具有一次性特性，UploadFile.SaveFile与UploadFile.ReadBytes只能使用其中一个，另外一个将无法正常获取数据
* 增加dotweb.Version，用于输出框架版本号
* Readme增加基于dotweb与mapper实现的yulibaozi.com博客源码链接
* 2018-01-21 09:00