### PR TITLE
#### Version 1.4.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: required
 
 go:
-  - 1.8
+  - 1.9
 
 env:
     - GO15VENDOREXPERIMENT="1"

--- a/dotweb.go
+++ b/dotweb.go
@@ -55,6 +55,8 @@ const (
 	// DefaultHTTPPort default http port; fixed for #70 UPDATE default http port 80 to 8080
 	DefaultHTTPPort           = 8080
 
+	DefaultLogPath = ""
+
 	// RunMode_Development app runmode in development mode
 	RunMode_Development       = "development"
 	// RunMode_Production app runmode in production mode

--- a/dotweb.go
+++ b/dotweb.go
@@ -88,19 +88,31 @@ func New() *DotWeb {
 	return app
 }
 
-// Classic create and return DotApp instance
+// Classic create and return DotApp instance\
+// if set logPath = "", it  will use bin-root/logs for log-root
 // 1.SetEnabledLog(true)
 // 2.use RequestLog Middleware
 // 3.print logo
-func Classic() *DotWeb {
+func Classic(logPath string) *DotWeb {
 	app := New()
 	app.StartMode = StartMode_Classic
 
+	if logPath != ""{
+		app.SetLogPath(logPath)
+	}
 	app.SetEnabledLog(true)
 	app.UseRequestLog()
 	//print logo
 	printDotLogo()
 	logger.Logger().Debug("DotWeb Start New AppServer", LogTarget_HttpServer)
+	return app
+}
+
+// ClassicWithConf create and return DotApp instance
+// must set config info
+func ClassicWithConf(config *config.Config) *DotWeb{
+	app := Classic(config.App.LogPath)
+	app.SetConfig(config)
 	return app
 }
 

--- a/example/start/main.go
+++ b/example/start/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main(){
-	app := dotweb.Classic()
+	app := dotweb.Classic(dotweb.DefaultLogPath)
 	//app := dotweb.New()
 	//开启development模式
 	app.SetDevelopmentMode()

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -69,7 +69,7 @@ func SetEnabledConsole(enabled bool) {
 
 func InitLog() {
 	if DefaultLogPath == "" {
-		DefaultLogPath = file.GetCurrentDirectory()
+		DefaultLogPath = file.GetCurrentDirectory() +"/logs"
 	}
 	if appLog == nil {
 		appLog = NewXLog()

--- a/uploadfile.go
+++ b/uploadfile.go
@@ -26,11 +26,6 @@ func NewUploadFile(file multipart.File, header *multipart.FileHeader) *UploadFil
 	}
 }
 
-// 获取文件大小的接口
-type sizer interface {
-	Size() int64
-}
-
 //get upload file client-local name
 func (f *UploadFile) FileName() string {
 	return f.fileName
@@ -38,12 +33,7 @@ func (f *UploadFile) FileName() string {
 
 //get upload file size
 func (f *UploadFile) Size() int64 {
-	if f.fileSize <= 0 {
-		if sizer, ok := f.File.(sizer); ok {
-			f.fileSize = sizer.Size()
-		}
-	}
-	return f.fileSize
+	return f.Header.Size
 }
 
 // SaveFile save file in server-local with filename

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,12 @@
 ## dotweb版本记录：
 
+#### Version 1.4.9.3
+* 调整UploadFile.Size实现方法，直接返回Header.Size数据
+* 调整dotweb.Classic签名为Classic(logPath string),若传入logPath为空，则默认以"bin-root/logs"为日志目录
+* 新增dotweb.ClassicWithConf(config *config.Config),支持初始化传入config设置
+* 调整默认Log目录由"bin-root"为"bin-root/logs"
+* 2018-04-24 08:30
+
 #### Version 1.4.9.2
 * 修复BUG for #112
 * 调整CharsetUTF8值为"charset=utf-8"

--- a/version.MD
+++ b/version.MD
@@ -1,6 +1,7 @@
 ## dotweb版本记录：
 
 #### Version 1.4.9.3
+* 重要：go版本适配升级为1.9+
 * 调整UploadFile.Size实现方法，直接返回Header.Size数据
 * 调整dotweb.Classic签名为Classic(logPath string),若传入logPath为空，则默认以"bin-root/logs"为日志目录
 * 新增dotweb.ClassicWithConf(config *config.Config),支持初始化传入config设置


### PR DESCRIPTION
* 重要：go版本适配升级为1.9+
* 调整UploadFile.Size实现方法，直接返回Header.Size数据
* 调整dotweb.Classic签名为Classic(logPath string),若传入logPath为空，则默认以"bin-root/logs"为日志目录
* 新增dotweb.ClassicWithConf(config *config.Config),支持初始化传入config设置
* 调整默认Log目录由"bin-root"为"bin-root/logs"
* 2018-04-24 08:30