### PR TITLE
Version 1.4.9.4

### DIFF
--- a/cache/runtime/cache_runtime_test.go
+++ b/cache/runtime/cache_runtime_test.go
@@ -100,18 +100,18 @@ func TestRuntimeCache_ClearAll(t *testing.T) {
 	cache.Set("2",TEST_CACHE_VALUE,5)
 	cache.Set("3",TEST_CACHE_VALUE,5)
 
-	val_2, err := cache.GetString("2")
+	val2, err := cache.GetString("2")
 	if err != nil{
 		t.Error(err)
 	}
-	test.Equal(t,TEST_CACHE_VALUE, val_2)
+	test.Equal(t,TEST_CACHE_VALUE, val2)
 
 	cache.ClearAll()
-	exists_2, err := cache.Exists("2")
+	exists2, err := cache.Exists("2")
 	if err != nil{
 		t.Error(err)
 	}
-	if exists_2{
+	if exists2{
 		t.Error("exists 2 but need not exists")
 	}
 }

--- a/cache/runtime/cache_runtime_test.go
+++ b/cache/runtime/cache_runtime_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 func TestRuntimeCache_Get(t *testing.T) {
-	cache:=NewTestRuntimeCache()
+	cache:=NewRuntimeCache()
 	cache.Set(TEST_CACHE_KEY,TEST_CACHE_VALUE,5)
 	//check value
 	go func(cache *RuntimeCache,t *testing.T) {
@@ -64,7 +64,7 @@ func TestRuntimeCache_GetString(t *testing.T) {
 }
 
 func testRuntimeCache(t *testing.T,insertValue interface{},f func(cache *RuntimeCache,key string)(interface{}, error)) {
-	cache:=NewTestRuntimeCache()
+	cache:=NewRuntimeCache()
 	cache.Set(TEST_CACHE_KEY,insertValue,5)
 	//check value
 	go func(cache *RuntimeCache,t *testing.T) {
@@ -79,7 +79,7 @@ func testRuntimeCache(t *testing.T,insertValue interface{},f func(cache *Runtime
 }
 
 func TestRuntimeCache_Delete(t *testing.T) {
-	cache:=NewTestRuntimeCache()
+	cache:=NewRuntimeCache()
 	cache.Set(TEST_CACHE_KEY,TEST_CACHE_VALUE,5)
 
 	value,e:=cache.Get(TEST_CACHE_KEY)
@@ -95,20 +95,29 @@ func TestRuntimeCache_Delete(t *testing.T) {
 }
 
 func TestRuntimeCache_ClearAll(t *testing.T) {
-	cache:=NewTestRuntimeCache()
+	cache:=NewRuntimeCache()
 	cache.Set(TEST_CACHE_KEY,TEST_CACHE_VALUE,5)
 	cache.Set("2",TEST_CACHE_VALUE,5)
 	cache.Set("3",TEST_CACHE_VALUE,5)
 
-	test.Equal(t,3,len(cache.items))
+	val_2, err := cache.GetString("2")
+	if err != nil{
+		t.Error(err)
+	}
+	test.Equal(t,TEST_CACHE_VALUE, val_2)
 
 	cache.ClearAll()
-
-	test.Equal(t,0,len(cache.items))
+	exists_2, err := cache.Exists("2")
+	if err != nil{
+		t.Error(err)
+	}
+	if exists_2{
+		t.Error("exists 2 but need not exists")
+	}
 }
 
 func TestRuntimeCache_Incr(t *testing.T) {
-	cache:=NewTestRuntimeCache()
+	cache:=NewRuntimeCache()
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -136,7 +145,7 @@ func TestRuntimeCache_Incr(t *testing.T) {
 }
 
 func TestRuntimeCache_Decr(t *testing.T) {
-	cache:=NewTestRuntimeCache()
+	cache:=NewRuntimeCache()
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -161,10 +170,4 @@ func TestRuntimeCache_Decr(t *testing.T) {
 	test.Nil(t,e)
 
 	test.Equal(t,-100,value)
-}
-
-func NewTestRuntimeCache() *RuntimeCache {
-	cache := RuntimeCache{items: make(map[string]*RuntimeItem), gcInterval: DefaultTestGCInterval}
-	go cache.gc()
-	return &cache
 }

--- a/const/const.go
+++ b/const/const.go
@@ -2,5 +2,5 @@ package _const
 
 //dotweb const
 const (
-	Version = "1.4.8"
+	Version = "1.4.9.4"
 )

--- a/core/state.go
+++ b/core/state.go
@@ -117,6 +117,8 @@ type ServerStateInfo struct {
 //ShowHtmlData show server state data html-string format
 func (state *ServerStateInfo) ShowHtmlData() string {
 	data := "<html><body><div>"
+	data += "CurrentTime : " + time.Now().Format("2006-01-02 15:04:05")
+	data += "<br>"
 	data += "ServerVersion : " + _const.Version
 	data += "<br>"
 	data += "ServerStartTime : " + state.ServerStartTime.Format(dateTimeLayout)

--- a/dotweb.go
+++ b/dotweb.go
@@ -103,7 +103,6 @@ func Classic(logPath string) *DotWeb {
 		app.SetLogPath(logPath)
 	}
 	app.SetEnabledLog(true)
-	app.UseRequestLog()
 	//print logo
 	printDotLogo()
 	logger.Logger().Debug("DotWeb Start New AppServer", LogTarget_HttpServer)

--- a/response.go
+++ b/response.go
@@ -129,6 +129,7 @@ func (r *Response) reset(w http.ResponseWriter) {
 	r.header = w.Header()
 	r.Status = http.StatusOK
 	r.Size = 0
+	r.body = nil
 	r.committed = false
 }
 
@@ -138,6 +139,7 @@ func (r *Response) release() {
 	r.header = nil
 	r.Status = http.StatusOK
 	r.Size = 0
+	r.body = nil
 	r.committed = false
 }
 

--- a/session/store_redis.go
+++ b/session/store_redis.go
@@ -49,7 +49,7 @@ func (store *RedisStore) SessionRead(sessionId string) (*SessionState, error) {
 		}
 	}
 	state := NewSessionState(store, sessionId, kv)
-	go store.SessionUpdate(state)
+	go store.sessionReExpire(state)
 	return state, nil
 }
 
@@ -62,6 +62,14 @@ func (store *RedisStore) SessionExist(sessionId string) bool {
 		return false
 	}
 	return exists
+}
+
+// sessionReExpire reset expire session key
+func (store *RedisStore) sessionReExpire(state *SessionState) error {
+	redisClient := redisutil.GetRedisClient(store.serverIp)
+	key := getRedisKey(state.SessionID())
+	_, err := redisClient.Expire(key, store.maxlifetime)
+	return err
 }
 
 //SessionUpdate update session state in store

--- a/version.MD
+++ b/version.MD
@@ -4,6 +4,7 @@
 #### Version 1.4.9.4
 * 调整: dotweb.Classic移除自动UseRequestLog逻辑
 * 调整：Session Redis模式时，新增sessionReExpire用于重置有效期，避免调用SessionUpdate导致不必要的redis数据交换
+* 调整：Cache.Runtime调整map为sync.Map
 * 状态页：访问/dotweb/state时增加CurrentTime字段输出
 * BUG： 修正Reponse自动释放时未重置body字段，导致内存溢出BUG
 * 2018-05-10 13:30

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,12 @@
 ## dotweb版本记录：
 
+
+#### Version 1.4.9.4
+* 调整: dotweb.Classic移除自动UseRequestLog逻辑
+* 调整：Session Redis模式时，当解析map失败时仅标准输出提示，不暴露该异常
+* 状态页：访问/dotweb/state时增加CurrentTime字段输出
+* 2018-05-10 13:30
+
 #### Version 1.4.9.3
 * 重要：go版本适配升级为1.9+
 * 调整UploadFile.Size实现方法，直接返回Header.Size数据

--- a/version.MD
+++ b/version.MD
@@ -3,7 +3,7 @@
 
 #### Version 1.4.9.4
 * 调整: dotweb.Classic移除自动UseRequestLog逻辑
-* 调整：Session Redis模式时，当解析map失败时仅标准输出提示，不暴露该异常
+* 调整：Session Redis模式时，新增sessionReExpire用于重置有效期，避免调用SessionUpdate导致不必要的redis数据交换
 * 状态页：访问/dotweb/state时增加CurrentTime字段输出
 * BUG： 修正Reponse自动释放时未重置body字段，导致内存溢出BUG
 * 2018-05-10 13:30

--- a/version.MD
+++ b/version.MD
@@ -5,6 +5,7 @@
 * 调整: dotweb.Classic移除自动UseRequestLog逻辑
 * 调整：Session Redis模式时，当解析map失败时仅标准输出提示，不暴露该异常
 * 状态页：访问/dotweb/state时增加CurrentTime字段输出
+* BUG： 修正Reponse自动释放时未重置body字段，导致内存溢出BUG
 * 2018-05-10 13:30
 
 #### Version 1.4.9.3


### PR DESCRIPTION
#### Version 1.4.9.4
* 调整: dotweb.Classic移除自动UseRequestLog逻辑
* 调整：Session Redis模式时，新增sessionReExpire用于重置有效期，避免调用SessionUpdate导致不必要的redis数据交换
* 调整：Cache.Runtime调整map为sync.Map
* 状态页：访问/dotweb/state时增加CurrentTime字段输出
* BUG： 修正Reponse自动释放时未重置body字段，导致内存溢出BUG
* 2018-05-10 13:30