### PR TITLE
Version 1.5.2

### DIFF
--- a/dotweb.go
+++ b/dotweb.go
@@ -69,6 +69,7 @@ const (
 )
 
 //New create and return DotApp instance
+//default run mode is RunMode_Production
 func New() *DotWeb {
 	app := &DotWeb{
 		HttpServer:      NewHttpServer(),
@@ -80,6 +81,8 @@ func New() *DotWeb {
 		middlewareMutex: new(sync.RWMutex),
 		StartMode:       StartMode_New,
 	}
+	//set default run mode = RunMode_Production
+	app.Config.App.RunMode = RunMode_Production
 	app.HttpServer.setDotApp(app)
 	//add default httphandler with middlewares
 	//fixed for issue #100
@@ -538,7 +541,6 @@ func (app *DotWeb) initServerEnvironment() {
 		}else{
 			app.HttpServer.SetRenderer(NewInnerRenderer())
 		}
-
 	}
 
 	//start pprof server

--- a/dotweb.go
+++ b/dotweb.go
@@ -531,8 +531,14 @@ func (app *DotWeb) initServerEnvironment() {
 	}
 
 	//if renderer not set, create inner renderer
+	//if is develop mode, it will use nocache mode
 	if app.HttpServer.Renderer() == nil {
-		app.HttpServer.SetRenderer(NewInnerRenderer())
+		if app.RunMode() == RunMode_Development{
+			app.HttpServer.SetRenderer(NewInnerRendererNoCache())
+		}else{
+			app.HttpServer.SetRenderer(NewInnerRenderer())
+		}
+
 	}
 
 	//start pprof server

--- a/example/render/main.go
+++ b/example/render/main.go
@@ -14,6 +14,8 @@ func main() {
 	//设置dotserver日志目录
 	app.SetLogPath(file.GetCurrentDirectory())
 
+	//app.SetDevelopmentMode()
+
 	//设置gzip开关
 	//app.HttpServer.SetEnabledGzip(true)
 

--- a/render.go
+++ b/render.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"path"
 	"sync"
+	"fmt"
 )
 
 // Renderer is the interface that wraps the render method.
@@ -52,8 +53,13 @@ func (r *innerRenderer) parseFiles(fileNames ...string) (*template.Template, err
 		filesCacheKey = filesCacheKey + v
 	}
 
-	//check from chach
-	t, exists:= r.parseFilesFromCache(filesCacheKey)
+	var t *template.Template
+	var exists bool
+	if r.enabledCache {
+		//check from chach
+		t, exists = r.parseFilesFromCache(filesCacheKey)
+	}
+	fmt.Println("parseFiles", r.enabledCache, filesCacheKey, t, exists)
 	if !exists{
 		t, err = template.ParseFiles(realFileNames...)
 		if err != nil {

--- a/render.go
+++ b/render.go
@@ -86,7 +86,7 @@ func registeTemplateFunc(t *template.Template) *template.Template {
 }
 
 // NewInnerRenderer create a inner renderer instance
-func NewInnerRenderer() *innerRenderer {
+func NewInnerRenderer() Renderer {
 	r := new(innerRenderer)
 	r.enabledCache = true
 	r.templateCache = make(map[string]*template.Template)
@@ -94,7 +94,7 @@ func NewInnerRenderer() *innerRenderer {
 }
 
 // NewInnerRendererNoCache create a inner renderer instance with no cache mode
-func NewInnerRendererNoCache() *innerRenderer {
+func NewInnerRendererNoCache() Renderer {
 	r := new(innerRenderer)
 	r.enabledCache = false
 	r.templateCache = make(map[string]*template.Template)

--- a/render.go
+++ b/render.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"io"
 	"path"
+	"sync"
 )
 
 // Renderer is the interface that wraps the render method.
@@ -15,6 +16,10 @@ type Renderer interface {
 
 type innerRenderer struct {
 	templatePath string
+	// Template cache (for FromCache())
+	enabledCache 	   bool
+	templateCache      map[string]*template.Template
+	templateCacheMutex sync.RWMutex
 }
 
 // Render render view use http/template
@@ -37,18 +42,37 @@ func unescaped(x string) interface{} { return template.HTML(x) }
 // return http/template by gived file name
 func (r *innerRenderer) parseFiles(fileNames ...string) (*template.Template, error) {
 	var realFileNames []string
+	var filesCacheKey string
+	var err error
 	for _, v := range fileNames {
 		if !file.Exist(v) {
 			v = path.Join(r.templatePath, v)
 		}
 		realFileNames = append(realFileNames, v)
+		filesCacheKey = filesCacheKey + v
 	}
-	t, err := template.ParseFiles(realFileNames...)
-	if err != nil {
-		return nil, err
+
+	//check from chach
+	t, exists:= r.parseFilesFromCache(filesCacheKey)
+	if !exists{
+		t, err = template.ParseFiles(realFileNames...)
+		if err != nil {
+			return nil, err
+		}
+		r.templateCacheMutex.Lock()
+		defer r.templateCacheMutex.Unlock()
+		r.templateCache[filesCacheKey] = t
 	}
+
 	t = registeTemplateFunc(t)
 	return t, nil
+}
+
+func (r *innerRenderer) parseFilesFromCache(filesCacheKey string) (*template.Template, bool){
+	r.templateCacheMutex.RLock()
+	defer r.templateCacheMutex.RUnlock()
+	t, exists:= r.templateCache[filesCacheKey]
+	return t, exists
 }
 
 // registeTemplateFunc registe default support funcs
@@ -60,5 +84,16 @@ func registeTemplateFunc(t *template.Template) *template.Template {
 // NewInnerRenderer create a inner renderer instance
 func NewInnerRenderer() *innerRenderer {
 	r := new(innerRenderer)
+	r.enabledCache = true
+	r.templateCache = make(map[string]*template.Template)
 	return r
 }
+
+// NewInnerRenderer create a inner renderer instance
+func NewInnerRendererNoCache() *innerRenderer {
+	r := new(innerRenderer)
+	r.enabledCache = false
+	r.templateCache = make(map[string]*template.Template)
+	return r
+}
+

--- a/render.go
+++ b/render.go
@@ -93,7 +93,7 @@ func NewInnerRenderer() *innerRenderer {
 	return r
 }
 
-// NewInnerRenderer create a inner renderer instance
+// NewInnerRendererNoCache create a inner renderer instance with no cache mode
 func NewInnerRendererNoCache() *innerRenderer {
 	r := new(innerRenderer)
 	r.enabledCache = false

--- a/render.go
+++ b/render.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"path"
 	"sync"
-	"fmt"
 )
 
 // Renderer is the interface that wraps the render method.
@@ -59,7 +58,6 @@ func (r *innerRenderer) parseFiles(fileNames ...string) (*template.Template, err
 		//check from chach
 		t, exists = r.parseFilesFromCache(filesCacheKey)
 	}
-	fmt.Println("parseFiles", r.enabledCache, filesCacheKey, t, exists)
 	if !exists{
 		t, err = template.ParseFiles(realFileNames...)
 		if err != nil {

--- a/server.go
+++ b/server.go
@@ -319,7 +319,11 @@ func (server *HttpServer) Binder() Binder {
 // if no set, init InnerRenderer
 func (server *HttpServer) Renderer() Renderer {
 	if server.render == nil {
-		server.render = NewInnerRenderer()
+		if server.DotApp.RunMode() == RunMode_Development{
+			server.SetRenderer(NewInnerRendererNoCache())
+		}else{
+			server.SetRenderer(NewInnerRenderer())
+		}
 	}
 	return server.render
 }

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,11 @@
 ## dotweb版本记录：
 
+#### Version 1.5.2
+* New feature: dotweb.innerRenderer add cache mode, default is enabled
+* New feature: dotweb.innerRenderer add NewInnerRendererNoCache() used to disabled cache
+* Update for app run_mode: if it's develop run mode, the default renderer will use no cache mode
+* 2018-06-22 14:00
+
 #### Version 1.5.1
 * Fixed Bug: double sprintf on logger.xlog
 * 2018-06-15 14:00


### PR DESCRIPTION
#### Version 1.5.2
* New feature: dotweb.innerRenderer add cache mode, default is enabled
* New feature: dotweb.innerRenderer add NewInnerRendererNoCache() used to disabled cache
* Update for app run_mode: if it's develop run mode, the default renderer will use no cache mode
* 2018-06-22 14:00
