### PR TITLE
Version 1.5.3

### DIFF
--- a/context.go
+++ b/context.go
@@ -66,6 +66,8 @@ type (
 		Inline(file string, name string) error
 		Bind(i interface{}) error
 		BindJsonBody(i interface{}) error
+		// Validate validates provided `i`. It is usually called after `Context#Bind()`.
+		Validate(i interface{}) error
 		GetRouterName(key string) string
 		RemoteIP() string
 		SetCookieValue(name, value string, maxAge int)
@@ -425,6 +427,14 @@ func (ctx *HttpContext) Bind(i interface{}) error {
 // BindJsonBody default use json decode req.Body to struct
 func (ctx *HttpContext) BindJsonBody(i interface{}) error {
 	return ctx.httpServer.Binder().BindJsonBody(i, ctx)
+}
+// Validate validates data with HttpServer::Validator
+// We will implementing inner validator on next version
+func (ctx *HttpContext) Validate(i interface{}) error {
+	if ctx.httpServer.Validator == nil {
+		return ErrValidatorNotRegistered
+	}
+	return ctx.httpServer.Validator.Validate(i)
 }
 
 // GetRouterName get router name

--- a/dotweb.go
+++ b/dotweb.go
@@ -436,7 +436,7 @@ func (app *DotWeb) initBindMiddleware() {
 	router := app.HttpServer.Router().(*router)
 	//bind app middlewares
 	for fullExpress, _ := range router.allRouterExpress {
-		expresses := strings.Split(fullExpress, "_")
+		expresses := strings.Split(fullExpress, routerExpress_Split)
 		if len(expresses) < 2 {
 			continue
 		}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,5 @@
+package dotweb
+
+import "errors"
+
+var ErrValidatorNotRegistered = errors.New("validator not registered")

--- a/router.go
+++ b/router.go
@@ -31,6 +31,10 @@ const (
 	RouteMethod_WebSocket = "WEBSOCKET"
 )
 
+const(
+	routerExpress_Split = "^$^"
+)
+
 var (
 	HttpMethodMap map[string]string
 	valueNodePool sync.Pool
@@ -500,7 +504,7 @@ func (r *router) add(method, path string, handle RouterHandle, m ...Middleware) 
 	//fmt.Println("Handle => ", method, " - ", *root, " - ", path)
 	outnode = root.addRoute(path, handle, m...)
 	outnode.fullPath = path
-	r.allRouterExpress[method+"_"+path] = struct{}{}
+	r.allRouterExpress[method+routerExpress_Split+path] = struct{}{}
 	return
 }
 

--- a/server.go
+++ b/server.go
@@ -29,6 +29,7 @@ type (
 		groups	 	   []Group
 		Modules        []*HttpModule
 		DotApp         *DotWeb
+		Validator      Validator
 		sessionManager *session.SessionManager
 		lock_session   *sync.RWMutex
 		pool           *pool

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,6 @@
+package dotweb
+
+// Validator is the interface that wraps the Validate function.
+type Validator interface {
+	Validate(i interface{}) error
+}

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,11 @@
 ## dotweb版本记录：
 
+#### Version 1.5.3
+* New feature: HttpServer add Validator which be called by Context.Validate()
+* New feature: Context add Validate(interface{}) used to validate data with HttpServer::Validator
+* Update: use routerExpress_Split replace "_" when padding data to Router::RouterExpress
+* 2018-07-12 12:00
+
 #### Version 1.5.2
 * New feature: dotweb.innerRenderer add cache mode, default is enabled
 * New feature: dotweb.innerRenderer add NewInnerRendererNoCache() used to disabled cache


### PR DESCRIPTION
* New feature: HttpServer add Validator which be called by Context.Validate()
* New feature: Context add Validate(interface{}) used to validate data with HttpServer::Validator
* Update: use routerExpress_Split replace "_" when padding data to Router::RouterExpress
* 2018-07-12 12:00