### PR TITLE
Version 1.5.4

### DIFF
--- a/config/configs.go
+++ b/config/configs.go
@@ -60,10 +60,11 @@ type (
 	// SessionNode dotweb app's session config
 	SessionNode struct {
 		EnabledSession bool   `xml:"enabled,attr"`  //启用Session
-		SessionMode    string `xml:"mode,attr"`     //session模式，目前支持runtime、redis
-		Timeout        int64  `xml:"timeout,attr"`  //session超时时间，分为单位
-		ServerIP       string `xml:"serverip,attr"` //远程session serverip
-		StoreKeyPre 	string `xml:"storekeypre,attr"` //远程session StoreKeyPre
+		SessionMode    string `xml:"mode,attr"`     //session mode，now support runtime、redis
+		CookieName	   string `xml:"cookiename,attr"` //custom cookie name which sessionid store, default is dotweb_sessionId
+		Timeout        int64  `xml:"timeout,attr"`  //session time-out period, with minute
+		ServerIP       string `xml:"serverip,attr"` //remote session server url
+		StoreKeyPre 	string `xml:"storekeypre,attr"` //remote session StoreKeyPre
 	}
 
 	// RouterNode dotweb app's router config

--- a/consts.go
+++ b/consts.go
@@ -2,7 +2,7 @@ package dotweb
 
 //Global define
 const(
-	Version = "1.4.9.6"
+	Version = "1.5.4"
 )
 
 //Log define

--- a/dotweb.go
+++ b/dotweb.go
@@ -348,12 +348,6 @@ func (app *DotWeb) initAppConfig() {
 		app.OfflineServer.SetOffline(config.Offline.Offline, config.Offline.OfflineText, config.Offline.OfflineUrl)
 	}
 
-	//设置session
-	if config.Session.EnabledSession {
-		app.HttpServer.SetEnabledSession(config.Session.EnabledSession)
-		app.HttpServer.SetSessionConfig(session.NewStoreConfig(config.Session.SessionMode, config.Session.Timeout, config.Session.ServerIP, config.Session.StoreKeyPre))
-	}
-
 	//设置启用详细请求数据统计
 	if config.Server.EnabledDetailRequestData {
 		core.GlobalState.EnabledDetailRequestData = config.Server.EnabledDetailRequestData

--- a/feature.go
+++ b/feature.go
@@ -34,7 +34,7 @@ func (f *xFeatureTools) SetSession(httpCtx *HttpContext) {
 	} else {
 		httpCtx.sessionID = httpCtx.HttpServer().GetSessionManager().NewSessionID()
 		cookie := &http.Cookie{
-			Name:  httpCtx.HttpServer().sessionManager.CookieName,
+			Name:  httpCtx.HttpServer().sessionManager.StoreConfig().CookieName,
 			Value: url.QueryEscape(httpCtx.SessionID()),
 			Path:  "/",
 		}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,10 +9,14 @@ import (
 )
 
 const (
-	LogLevel_Debug = "DEBUG"
-	LogLevel_Info  = "INFO"
-	LogLevel_Warn  = "WARN"
-	LogLevel_Error = "ERROR"
+	// LogLevelDebug debug log level
+	LogLevelDebug = "DEBUG"
+	// LogLevelInfo info log level
+	LogLevelInfo  = "INFO"
+	// LogLevelWarn warn log level
+	LogLevelWarn  = "WARN"
+	// LogLevelError error log level
+	LogLevelError = "ERROR"
 )
 
 type AppLog interface {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	LogLevel_Debug = "debug"
-	LogLevel_Info  = "info"
-	LogLevel_Warn  = "warn"
-	LogLevel_Error = "error"
+	LogLevel_Debug = "DEBUG"
+	LogLevel_Info  = "INFO"
+	LogLevel_Warn  = "WARN"
+	LogLevel_Error = "ERROR"
 )
 
 type AppLog interface {

--- a/logger/xlog.go
+++ b/logger/xlog.go
@@ -41,27 +41,27 @@ const (
 
 // Debug debug log with default format
 func (l *xLog) Debug(log string, logTarget string) {
-	l.log(log, logTarget, LogLevel_Debug, false)
+	l.log(log, logTarget, LogLevelDebug, false)
 }
 
 // Print debug log with no format
 func (l *xLog) Print(log string, logTarget string) {
-	l.log(log, logTarget, LogLevel_Debug, true)
+	l.log(log, logTarget, LogLevelDebug, true)
 }
 
 // Info info log with default format
 func (l *xLog) Info(log string, logTarget string) {
-	l.log(log, logTarget, LogLevel_Info, false)
+	l.log(log, logTarget, LogLevelInfo, false)
 }
 
 // Warn warn log with default format
 func (l *xLog) Warn(log string, logTarget string) {
-	l.log(log, logTarget, LogLevel_Warn, false)
+	l.log(log, logTarget, LogLevelWarn, false)
 }
 
 // Error error log with default format
 func (l *xLog) Error(log string, logTarget string) {
-	l.log(log, logTarget, LogLevel_Error, false)
+	l.log(log, logTarget, LogLevelError, false)
 }
 
 // log push log into chan

--- a/logger/xlog.go
+++ b/logger/xlog.go
@@ -120,7 +120,7 @@ func (l *xLog) writeLog(chanLog chanLog, level string) {
 	}
 	log := chanLog.Content
 	if !chanLog.isRaw {
-		log = fmt.Sprintf("[%s] %s [%s:%v] %s", chanLog.LogLevel, time.Now().Format(defaultFullTimeLayout), chanLog.logCtx.fileName, chanLog.logCtx.line, chanLog.Content)
+		log = fmt.Sprintf("%s [%s] [%s:%v] %s", time.Now().Format(defaultFullTimeLayout), chanLog.LogLevel, chanLog.logCtx.fileName, chanLog.logCtx.line, chanLog.Content)
 	}
 	if l.enabledConsole {
 		fmt.Println(log)

--- a/server.go
+++ b/server.go
@@ -206,6 +206,7 @@ func (server *HttpServer) SetSessionConfig(storeConfig *session.StoreConfig) {
 	server.SessionConfig().SessionMode = storeConfig.StoreName
 	server.SessionConfig().ServerIP = storeConfig.ServerIP
 	server.SessionConfig().StoreKeyPre = storeConfig.StoreKeyPre
+	server.SessionConfig().CookieName = storeConfig.CookieName
 	logger.Logger().Debug("DotWeb:HttpServer SetSessionConfig ["+jsonutil.GetJsonString(storeConfig)+"]", LogTarget_HttpServer)
 }
 
@@ -216,6 +217,7 @@ func (server *HttpServer) InitSessionManager() {
 	storeConfig.StoreName = server.SessionConfig().SessionMode
 	storeConfig.ServerIP = server.SessionConfig().ServerIP
 	storeConfig.StoreKeyPre = server.SessionConfig().StoreKeyPre
+	storeConfig.CookieName = server.SessionConfig().CookieName
 
 	if server.sessionManager == nil {
 		//设置Session

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,12 @@
 ## dotweb版本记录：
 
+#### Version 1.5.4
+* New feature: Session.StoreConfig support CookieName, used to set custom cookie name which sessionid store, default is dotweb_sessionId
+* Update: Config.SessionNode add CookieName, used to set custom cookie name which sessionid store
+* Update: default log format update to "Time [LogLevel] [FileName:Line] Content"
+* BugFixed: remove init session which exec on dotweb.initAppConfig
+* 2018-08-02 15:00
+
 #### Version 1.5.3
 * New feature: HttpServer add Validator which be called by Context.Validate()
 * New feature: Context add Validate(interface{}) used to validate data with HttpServer::Validator


### PR DESCRIPTION
* New feature: Session.StoreConfig support CookieName, used to set custom cookie name which sessionid store, default is dotweb_sessionId
* Update: Config.SessionNode add CookieName, used to set custom cookie name which sessionid store
* Update: default log format update to "Time [LogLevel] [FileName:Line] Content"
* BugFixed: remove init session which exec on dotweb.initAppConfig
* 2018-08-02 15:00