### PR TITLE
Version 1.5.6

### DIFF
--- a/config/configs.go
+++ b/config/configs.go
@@ -59,11 +59,12 @@ type (
 
 	// SessionNode dotweb app's session config
 	SessionNode struct {
-		EnabledSession bool   `xml:"enabled,attr"`  //启用Session
-		SessionMode    string `xml:"mode,attr"`     //session mode，now support runtime、redis
-		CookieName	   string `xml:"cookiename,attr"` //custom cookie name which sessionid store, default is dotweb_sessionId
-		Timeout        int64  `xml:"timeout,attr"`  //session time-out period, with minute
-		ServerIP       string `xml:"serverip,attr"` //remote session server url
+		EnabledSession 	bool   `xml:"enabled,attr"`  //启用Session
+		SessionMode    	string `xml:"mode,attr"`     //session mode，now support runtime、redis
+		CookieName	   	string `xml:"cookiename,attr"` //custom cookie name which sessionid store, default is dotweb_sessionId
+		Timeout        	int64  `xml:"timeout,attr"`  //session time-out period, with minute
+		ServerIP       	string `xml:"serverip,attr"` //remote session server url
+		BackupServerUrl	string `xml:"backupserverurl,attr"` //backup remote session server url
 		StoreKeyPre 	string `xml:"storekeypre,attr"` //remote session StoreKeyPre
 	}
 

--- a/framework/hystrix/counter.go
+++ b/framework/hystrix/counter.go
@@ -1,0 +1,54 @@
+package hystrix
+
+import (
+	"sync/atomic"
+)
+
+const	(
+	minuteTimeLayout = "200601021504"
+)
+
+
+
+
+
+
+// Counter incremented and decremented base on int64 value.
+type Counter interface {
+	Clear()
+	Count() int64
+	Dec(int64)
+	Inc(int64)
+}
+
+// NewCounter constructs a new StandardCounter.
+func NewCounter() Counter {
+	return &StandardCounter{}
+}
+
+
+// StandardCounter is the standard implementation of a Counter
+type StandardCounter struct {
+	count int64
+}
+
+// Clear sets the counter to zero.
+func (c *StandardCounter) Clear() {
+	atomic.StoreInt64(&c.count, 0)
+}
+
+// Count returns the current count.
+func (c *StandardCounter) Count() int64 {
+	return atomic.LoadInt64(&c.count)
+}
+
+// Dec decrements the counter by the given amount.
+func (c *StandardCounter) Dec(i int64) {
+	atomic.AddInt64(&c.count, -i)
+}
+
+// Inc increments the counter by the given amount.
+func (c *StandardCounter) Inc(i int64) {
+	atomic.AddInt64(&c.count, i)
+}
+

--- a/framework/hystrix/hystrix.go
+++ b/framework/hystrix/hystrix.go
@@ -1,0 +1,164 @@
+package hystrix
+
+import (
+	"time"
+	"sync"
+	"fmt"
+)
+
+const(
+	status_Hystrix = 1
+	status_Alive = 2
+	DefaultCheckHystrixInterval = 10 //unit is Second
+	DefaultCheckAliveInterval = 60 //unit is Second
+	DefaultMaxFailedNumber = 100
+)
+
+type Hystrix interface{
+	// Do begin do check
+	Do()
+	// RegisterAliveCheck register check Alive func
+	RegisterAliveCheck(CheckFunc)
+	// RegisterHystrixCheck register check Hystrix func
+	RegisterHystrixCheck(CheckFunc)
+	// IsHystrix return is Hystrix status
+	IsHystrix() bool
+	// TriggerHystrix trigger Hystrix status
+	TriggerHystrix()
+	// TriggerAlive trigger Alive status
+	TriggerAlive()
+	// SetCheckInterval set interval for doCheckHystric and doCheckAlive, unit is Second
+	SetCheckInterval(int, int)
+
+	// GetCounter get lasted Counter with time key
+	GetCounter() Counter
+
+	// SetMaxFailed set max failed count for hystrix default counter
+	SetMaxFailedNumber(int64)
+}
+
+type CheckFunc func()bool
+
+type StandHystrix struct{
+	status int
+	checkHystrixFunc CheckFunc
+	checkHystrixInterval int
+	checkAliveFunc CheckFunc
+	checkAliveInterval int
+
+	maxFailedNumber int64
+	counters *sync.Map
+}
+
+
+// NewHystrix create new Hystrix, config with CheckAliveFunc and checkAliveInterval, unit is Minute
+func NewHystrix(checkAlive CheckFunc, checkHysrix CheckFunc) Hystrix{
+	h := &StandHystrix{
+		counters : new(sync.Map),
+		status:status_Alive,
+		checkAliveFunc: checkAlive,
+		checkHystrixFunc:checkHysrix,
+		checkAliveInterval:DefaultCheckAliveInterval,
+		checkHystrixInterval:DefaultCheckHystrixInterval,
+		maxFailedNumber:DefaultMaxFailedNumber,
+	}
+	if h.checkHystrixFunc == nil{
+		h.checkHystrixFunc = h.defaultCheckHystrix
+	}
+	return h
+}
+
+func (h *StandHystrix) Do(){
+	go h.doCheck()
+}
+
+func (h *StandHystrix) SetCheckInterval(hystrixInterval, aliveInterval int){
+	h.checkAliveInterval = aliveInterval
+	h.checkHystrixInterval = hystrixInterval
+}
+
+// SetMaxFailed set max failed count for hystrix default counter
+func (h *StandHystrix) SetMaxFailedNumber(number int64){
+	h.maxFailedNumber = number
+}
+
+// GetCounter get lasted Counter with time key
+func (h *StandHystrix) GetCounter() Counter{
+	key := getLastedTimeKey()
+	var counter Counter
+	loadCounter, exists := h.counters.Load(key)
+	if !exists{
+		counter = NewCounter()
+		h.counters.Store(key, counter)
+	}else{
+		counter = loadCounter.(Counter)
+	}
+	return counter
+}
+
+
+func (h *StandHystrix) IsHystrix() bool{
+	return h.status == status_Hystrix
+}
+
+func (h *StandHystrix) RegisterAliveCheck(check CheckFunc){
+	h.checkAliveFunc = check
+}
+
+func (h *StandHystrix) RegisterHystrixCheck(check CheckFunc){
+	h.checkHystrixFunc = check
+}
+
+func (h *StandHystrix) TriggerHystrix(){
+	h.status = status_Hystrix
+}
+
+func (h *StandHystrix) TriggerAlive(){
+	h.status = status_Alive
+}
+
+
+// doCheck do checkAlive when status is Hystrix or checkHytrix when status is Alive
+func (h *StandHystrix) doCheck(){
+	if h.checkAliveFunc == nil || h.checkHystrixFunc == nil {
+		return
+	}
+	if h.IsHystrix() {
+		isAlive := h.checkAliveFunc()
+		if isAlive {
+			h.TriggerAlive()
+			h.GetCounter().Clear()
+			time.AfterFunc(time.Duration(h.checkHystrixInterval)*time.Second, h.doCheck)
+		} else {
+			time.AfterFunc(time.Duration(h.checkAliveInterval)*time.Second, h.doCheck)
+		}
+	}else{
+		isHystrix := h.checkHystrixFunc()
+		if isHystrix{
+			h.TriggerHystrix()
+			time.AfterFunc(time.Duration(h.checkAliveInterval)*time.Second, h.doCheck)
+		}else{
+			time.AfterFunc(time.Duration(h.checkHystrixInterval)*time.Second, h.doCheck)
+		}
+
+	}
+}
+
+func (h *StandHystrix) defaultCheckHystrix() bool{
+	count := h.GetCounter().Count()
+	if count > h.maxFailedNumber{
+		fmt.Println(time.Now(), "hystrix triggered!!",count)
+		return true
+	}else{
+		fmt.Println(time.Now(), "hystrix untriggered", count)
+		return false
+	}
+}
+
+func getLastedTimeKey() string{
+	key :=  time.Now().Format(minuteTimeLayout)
+	if time.Now().Minute() / 2 != 0{
+		key = time.Now().Add(time.Duration(-1*time.Minute)).Format(minuteTimeLayout)
+	}
+	return key
+}

--- a/server.go
+++ b/server.go
@@ -208,6 +208,7 @@ func (server *HttpServer) SetSessionConfig(storeConfig *session.StoreConfig) {
 	server.SessionConfig().Timeout = storeConfig.Maxlifetime
 	server.SessionConfig().SessionMode = storeConfig.StoreName
 	server.SessionConfig().ServerIP = storeConfig.ServerIP
+	server.SessionConfig().BackupServerUrl = storeConfig.BackupServerUrl
 	server.SessionConfig().StoreKeyPre = storeConfig.StoreKeyPre
 	server.SessionConfig().CookieName = storeConfig.CookieName
 	logger.Logger().Debug("DotWeb:HttpServer SetSessionConfig ["+jsonutil.GetJsonString(storeConfig)+"]", LogTarget_HttpServer)
@@ -219,6 +220,7 @@ func (server *HttpServer) InitSessionManager() {
 	storeConfig.Maxlifetime = server.SessionConfig().Timeout
 	storeConfig.StoreName = server.SessionConfig().SessionMode
 	storeConfig.ServerIP = server.SessionConfig().ServerIP
+	storeConfig.BackupServerUrl = server.SessionConfig().BackupServerUrl
 	storeConfig.StoreKeyPre = server.SessionConfig().StoreKeyPre
 	storeConfig.CookieName = server.SessionConfig().CookieName
 

--- a/session/session.go
+++ b/session/session.go
@@ -33,11 +33,12 @@ type (
 
 	//session config info
 	StoreConfig struct {
-		StoreName   string
-		Maxlifetime int64
-		CookieName  string //custom cookie name which sessionid store
-		ServerIP    string //if use redis, connection string, like "redis://:password@10.0.1.11:6379/0"
-		StoreKeyPre	string //if use redis, set custom redis key-pre; default is dotweb:session:
+		StoreName   	string
+		Maxlifetime 	int64
+		CookieName  	string //custom cookie name which sessionid store
+		ServerIP    	string //if use redis, connection string, like "redis://:password@10.0.1.11:6379/0"
+		BackupServerUrl string //if use redis, if ServerIP is down, use this server, like "redis://:password@10.0.1.11:6379/0"
+		StoreKeyPre		string //if use redis, set custom redis key-pre; default is dotweb:session:
 	}
 
 	SessionManager struct {

--- a/session/store_redis.go
+++ b/session/store_redis.go
@@ -5,35 +5,50 @@ import (
 	"github.com/devfeel/dotweb/framework/redis"
 	"sync"
 	"fmt"
+	"github.com/devfeel/dotweb/framework/hystrix"
+	"strings"
+	"time"
 )
 
 const (
 	defaultRedisKeyPre = "dotweb:session:"
+	HystrixErrorCount = 20
 )
 
 // RedisStore Implement the SessionStore interface
 type RedisStore struct {
+	hystrix hystrix.Hystrix
 	lock        *sync.RWMutex // locker
 	maxlifetime int64
 	serverIp    string //connection string, like "redis://:password@10.0.1.11:6379/0"
+	backupServerUrl string //backup connection string, like "redis://:password@10.0.1.11:6379/0"
 	storeKeyPre string //set custom redis key-pre; default is dotweb:session:
 }
 
 //create new redis store
 func NewRedisStore(config *StoreConfig) (*RedisStore, error){
 	store := &RedisStore{
-		lock:        new(sync.RWMutex),
-		serverIp:    config.ServerIP,
-		maxlifetime: config.Maxlifetime,
+		lock:        	new(sync.RWMutex),
+		serverIp:    	config.ServerIP,
+		backupServerUrl:config.BackupServerUrl,
+		maxlifetime: 	config.Maxlifetime,
 	}
+	store.hystrix = hystrix.NewHystrix(store.checkRedisAlive, nil)
+	store.hystrix.SetMaxFailedNumber(HystrixErrorCount)
+	store.hystrix.Do()
 	//init redis key-pre
 	if config.StoreKeyPre == ""{
 		store.storeKeyPre = defaultRedisKeyPre
 	}else{
 		store.storeKeyPre = config.StoreKeyPre
 	}
-	redisClient := redisutil.GetRedisClient(store.serverIp)
+	redisClient := store.getRedisClient()
 	_, err:=redisClient.Ping()
+	if store.checkConnErrorAndNeedRetry(err){
+		store.hystrix.TriggerHystrix()
+		redisClient = store.getBackupRedis()
+		_, err = redisClient.Ping()
+	}
 	return store, err
 }
 
@@ -43,9 +58,13 @@ func (store *RedisStore)getRedisKey(key string) string {
 
 // SessionRead get session state by sessionId
 func (store *RedisStore) SessionRead(sessionId string) (*SessionState, error) {
-	redisClient := redisutil.GetRedisClient(store.serverIp)
+	redisClient := store.getRedisClient()
 	key := store.getRedisKey(sessionId)
 	kvs, err := redisClient.Get(key)
+	if store.checkConnErrorAndNeedRetry(err){
+		redisClient = store.getBackupRedis()
+		kvs, err = redisClient.Get(key)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -65,9 +84,13 @@ func (store *RedisStore) SessionRead(sessionId string) (*SessionState, error) {
 
 // SessionExist check session state exist by sessionId
 func (store *RedisStore) SessionExist(sessionId string) bool {
-	redisClient := redisutil.GetRedisClient(store.serverIp)
+	redisClient := store.getRedisClient()
 	key := store.getRedisKey(sessionId)
 	exists, err := redisClient.Exists(key)
+	if store.checkConnErrorAndNeedRetry(err){
+		redisClient = store.getBackupRedis()
+		exists, err = redisClient.Exists(key)
+	}
 	if err != nil {
 		return false
 	}
@@ -76,9 +99,13 @@ func (store *RedisStore) SessionExist(sessionId string) bool {
 
 // sessionReExpire reset expire session key
 func (store *RedisStore) sessionReExpire(state *SessionState) error {
-	redisClient := redisutil.GetRedisClient(store.serverIp)
+	redisClient := store.getRedisClient()
 	key := store.getRedisKey(state.SessionID())
 	_, err := redisClient.Expire(key, store.maxlifetime)
+	if store.checkConnErrorAndNeedRetry(err){
+		redisClient = store.getBackupRedis()
+		_, err = redisClient.Expire(key, store.maxlifetime)
+	}
 	return err
 }
 
@@ -91,13 +118,17 @@ func (store *RedisStore) SessionUpdate(state *SessionState) error {
 			//TODO deal panic err
 		}
 	}()
-	redisClient := redisutil.GetRedisClient(store.serverIp)
+	redisClient := store.getRedisClient()
 	bytes, err := gob.EncodeMap(state.values)
 	if err != nil {
 		return err
 	}
 	key := store.getRedisKey(state.SessionID())
 	_, err = redisClient.SetWithExpire(key, string(bytes), store.maxlifetime)
+	if store.checkConnErrorAndNeedRetry(err){
+		redisClient = store.getBackupRedis()
+		_, err = redisClient.SetWithExpire(key, string(bytes), store.maxlifetime)
+	}
 	return err
 }
 
@@ -106,6 +137,10 @@ func (store *RedisStore) SessionRemove(sessionId string) error {
 	redisClient := redisutil.GetRedisClient(store.serverIp)
 	key := store.getRedisKey(sessionId)
 	_, err := redisClient.Del(key)
+	if store.checkConnErrorAndNeedRetry(err){
+		redisClient = store.getBackupRedis()
+		_, err = redisClient.Del(key)
+	}
 	return err
 }
 
@@ -118,4 +153,68 @@ func (store *RedisStore) SessionGC() int {
 // SessionAll get count number
 func (store *RedisStore) SessionCount() int {
 	return 0
+}
+
+
+// getRedisClient get alive redis client
+func (store *RedisStore) getRedisClient() *redisutil.RedisClient{
+	if store.hystrix.IsHystrix(){
+		if store.backupServerUrl != "" {
+			return store.getBackupRedis()
+		}
+	}
+	return store.getDefaultRedis()
+}
+
+func (store *RedisStore) getDefaultRedis() *redisutil.RedisClient{
+	return redisutil.GetRedisClient(store.serverIp)
+}
+
+func (store *RedisStore) getBackupRedis() *redisutil.RedisClient{
+	return redisutil.GetRedisClient(store.backupServerUrl)
+}
+
+// checkConnErrorAndNeedRetry check err is Conn error and is need to retry
+func (store *RedisStore) checkConnErrorAndNeedRetry(err error) bool{
+	if err == nil{
+		return false
+	}
+	if strings.Index(err.Error(), "no such host") >= 0 ||
+		strings.Index(err.Error(), "No connection could be made because the target machine actively refused it") >= 0 ||
+		strings.Index(err.Error(), "A connection attempt failed because the connected party did not properly respond after a period of time") >= 0 {
+		store.hystrix.GetCounter().Inc(1)
+		//if is hystrix, not to retry, because in getReadRedisClient already use backUp redis
+		if store.hystrix.IsHystrix(){
+			return false
+		}
+		if store.backupServerUrl == ""{
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// checkRedisAlive check redis is alive use ping
+// if set readonly redis, check readonly redis
+// if not set readonly redis, check default redis
+func (store *RedisStore) checkRedisAlive() bool{
+	isAlive := false
+	var redisClient *redisutil.RedisClient
+	redisClient = store.getDefaultRedis()
+	for i := 0;i<=5;i++ {
+		reply, err := redisClient.Ping()
+		fmt.Println(time.Now(), "checkAliveDefaultRedis Ping", reply, err)
+		if err != nil {
+			isAlive = false
+			break
+		}
+		if reply != "PONG" {
+			isAlive = false
+			break
+		}
+		isAlive = true
+		continue
+	}
+	return isAlive
 }

--- a/version.MD
+++ b/version.MD
@@ -5,6 +5,11 @@
 * New feature: Session.StoreConfig support BackupServerUrl, used to store session when default ServerIP redis is not available
 * Detail:
   - hystrix default MaxFailedNumber is 20 per 2 minutes
+- Example:
+  ```
+  sessionConf := session.NewDefaultRedisConfig("redis://10.10.0.1:6322/1")
+  sessionConf.BackupServerUrl = "redis://10.10.0.1:6379/1"
+  ```
 * 2018-08-09 15:00
 
 #### Version 1.5.5

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,12 @@
 ## dotweb版本记录：
 
+#### Version 1.5.6
+* New feature: add hystrix module, now is used to auto switch to backup redis session store
+* New feature: Session.StoreConfig support BackupServerUrl, used to store session when default ServerIP redis is not available
+* Detail:
+  - hystrix default MaxFailedNumber is 20 per 2 minutes
+* 2018-08-09 15:00
+
 #### Version 1.5.5
 * New feature: /dotweb/state add CurrentRequestCount data
 * Update: improve 30% performance on app's metric


### PR DESCRIPTION
#### Version 1.5.6
* New feature: add hystrix module, now is used to auto switch to backup redis session store
* New feature: Session.StoreConfig support BackupServerUrl, used to store session when default ServerIP redis is not available
* Detail:
  - hystrix default MaxFailedNumber is 20 per 2 minutes
- Example:
  ```
  sessionConf := session.NewDefaultRedisConfig("redis://10.10.0.1:6322/1")
  sessionConf.BackupServerUrl = "redis://10.10.0.1:6379/1"
  ```
* 2018-08-09 15:00