### PR TITLE
Version 1.5.6

### DIFF
--- a/framework/hystrix/hystrix.go
+++ b/framework/hystrix/hystrix.go
@@ -3,7 +3,6 @@ package hystrix
 import (
 	"time"
 	"sync"
-	"fmt"
 )
 
 const(
@@ -147,10 +146,10 @@ func (h *StandHystrix) doCheck(){
 func (h *StandHystrix) defaultCheckHystrix() bool{
 	count := h.GetCounter().Count()
 	if count > h.maxFailedNumber{
-		fmt.Println(time.Now(), "hystrix triggered!!",count)
+		//fmt.Println(time.Now(), "hystrix triggered!!",count)
 		return true
 	}else{
-		fmt.Println(time.Now(), "hystrix untriggered", count)
+		//fmt.Println(time.Now(), "hystrix untriggered", count)
 		return false
 	}
 }

--- a/framework/hystrix/hystrix.go
+++ b/framework/hystrix/hystrix.go
@@ -146,10 +146,8 @@ func (h *StandHystrix) doCheck(){
 func (h *StandHystrix) defaultCheckHystrix() bool{
 	count := h.GetCounter().Count()
 	if count > h.maxFailedNumber{
-		//fmt.Println(time.Now(), "hystrix triggered!!",count)
 		return true
 	}else{
-		//fmt.Println(time.Now(), "hystrix untriggered", count)
 		return false
 	}
 }

--- a/session/store_redis.go
+++ b/session/store_redis.go
@@ -203,7 +203,6 @@ func (store *RedisStore) checkRedisAlive() bool{
 	redisClient = store.getDefaultRedis()
 	for i := 0;i<=5;i++ {
 		reply, err := redisClient.Ping()
-		//fmt.Println(time.Now(), "checkAliveDefaultRedis Ping", reply, err)
 		if err != nil {
 			isAlive = false
 			break

--- a/session/store_redis.go
+++ b/session/store_redis.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/devfeel/dotweb/framework/hystrix"
 	"strings"
-	"time"
 )
 
 const (
@@ -204,7 +203,7 @@ func (store *RedisStore) checkRedisAlive() bool{
 	redisClient = store.getDefaultRedis()
 	for i := 0;i<=5;i++ {
 		reply, err := redisClient.Ping()
-		fmt.Println(time.Now(), "checkAliveDefaultRedis Ping", reply, err)
+		//fmt.Println(time.Now(), "checkAliveDefaultRedis Ping", reply, err)
 		if err != nil {
 			isAlive = false
 			break


### PR DESCRIPTION
#### Version 1.5.6
* New feature: add hystrix module, now is used to auto switch to backup redis session store
* New feature: Session.StoreConfig support BackupServerUrl, used to store session when default ServerIP redis is not available
* Detail:
  - hystrix default MaxFailedNumber is 20 per 2 minutes
- Example:
  ```
  sessionConf := session.NewDefaultRedisConfig("redis://10.10.0.1:6322/1")
  sessionConf.BackupServerUrl = "redis://10.10.0.1:6379/1"
  ```
* 2018-08-09 15:00