### PR TITLE
Version 1.5.7.3 - add HttpServer.VirtualPath

### DIFF
--- a/config/configs.go
+++ b/config/configs.go
@@ -55,6 +55,7 @@ type (
 		TLSKeyFile               string `xml:"tlskeyfile,attr"`               //TLS模式下秘钥文件地址
 		IndexPage                string `xml:"indexpage,attr"`                //默认index页面
 		EnabledDetailRequestData bool   `xml:"enableddetailrequestdata,attr"` //设置状态数据是否启用详细页面统计，默认不启用，请特别对待，如果站点url过多，会导致数据量过大
+		VirtualPath			     string //virtual path when deploy on no root path
 	}
 
 	// SessionNode dotweb app's session config

--- a/dotweb.go
+++ b/dotweb.go
@@ -353,12 +353,7 @@ func (app *DotWeb) initAppConfig() {
 		app.Config.App.RunMode = RunMode_Development
 	}
 
-	//CROS Config
-	if config.Server.EnabledAutoCORS {
-		app.HttpServer.Features.SetEnabledCROS()
-	}
-
-	app.HttpServer.SetEnabledGzip(config.Server.EnabledGzip)
+	app.HttpServer.initConfig()
 
 	//设置维护
 	if config.Offline.Offline {
@@ -508,7 +503,7 @@ func (app *DotWeb) initBindMiddleware() {
 // IncludeDotwebGroup init inner routers
 func (app *DotWeb) IncludeDotwebGroup() {
 	//默认支持pprof信息查看
-	gInner := app.HttpServer.Group("/dotweb")
+	gInner := app.HttpServer.Group(app.HttpServer.VirtualPath() + "/dotweb")
 	gInner.GET("/debug/pprof/:key", initPProf)
 	gInner.GET("/debug/freemem", freeMemory)
 	gInner.GET("/state", showServerState)

--- a/example/main.go
+++ b/example/main.go
@@ -39,6 +39,9 @@ func main() {
 	//设置Session开关
 	app.HttpServer.SetEnabledSession(true)
 
+	//set virtual path
+	app.HttpServer.SetVirtualPath("/1")
+
 	//1.use default config
 	//app.HttpServer.Features.SetEnabledCROS()
 	//2.use user config

--- a/server.go
+++ b/server.go
@@ -37,6 +37,7 @@ type (
 		render         Renderer
 		offline        bool
 		Features       *feature.Feature
+		virtualPath    string //virtual path when deploy on no root path
 	}
 
 	//pool定义
@@ -75,6 +76,20 @@ func NewHttpServer() *HttpServer {
 	server.router = NewRouter(server)
 	server.stdServer = &http.Server{Handler: server}
 	return server
+}
+
+// initConfig init config from app config
+func (server *HttpServer) initConfig(){
+	//CROS Config
+	if server.ServerConfig().EnabledAutoCORS {
+		server.Features.SetEnabledCROS()
+	}
+	server.SetEnabledGzip(server.ServerConfig().EnabledGzip)
+
+	//VirtualPath config
+	if server.virtualPath != ""{
+		server.virtualPath = server.ServerConfig().VirtualPath
+	}
 }
 
 // ServerConfig a shortcut for App.Config.ServerConfig
@@ -186,6 +201,16 @@ func (server *HttpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // IsOffline check server is set offline state
 func (server *HttpServer) IsOffline() bool {
 	return server.offline
+}
+
+// SetVirtualPath set current server's VirtualPath
+func (server *HttpServer) SetVirtualPath(path string){
+	server.virtualPath = path
+}
+
+// VirtualPath return current server's VirtualPath
+func (server *HttpServer) VirtualPath() string{
+	return server.virtualPath
 }
 
 // SetOffline set server offline config

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,12 @@
 ## dotweb版本记录：
 
+#### Version 1.5.7.3
+* New Feature: Add HttpServer.VirtualPath, used to set virtual path when deploy on no root path
+* Detail:
+  - when set virtual path "/vpath", if set route "/index", it will auto register "vpath/index"
+  - in effect on group & route
+* 2018-08-24 19:00
+
 #### Version 1.5.7.2
 * Fixed Bug: App.RunMode always is RunMode_Development
 * Update: Add RunMode log output


### PR DESCRIPTION
* New Feature: Add HttpServer.VirtualPath, used to set virtual path when deploy on no root path
* Detail:
  - when set virtual path "/vpath", if set route "/index", it will auto register "vpath/index"
  - in effect on group & route
* 2018-08-24 19:00