### PR TITLE
Version 1.5.7.3 - Add HttpServer.VirtualPath

### DIFF
--- a/dotweb.go
+++ b/dotweb.go
@@ -503,7 +503,7 @@ func (app *DotWeb) initBindMiddleware() {
 // IncludeDotwebGroup init inner routers
 func (app *DotWeb) IncludeDotwebGroup() {
 	//默认支持pprof信息查看
-	gInner := app.HttpServer.Group(app.HttpServer.VirtualPath() + "/dotweb")
+	gInner := app.HttpServer.Group("/dotweb")
 	gInner.GET("/debug/pprof/:key", initPProf)
 	gInner.GET("/debug/freemem", freeMemory)
 	gInner.GET("/state", showServerState)

--- a/server.go
+++ b/server.go
@@ -87,7 +87,7 @@ func (server *HttpServer) initConfig(){
 	server.SetEnabledGzip(server.ServerConfig().EnabledGzip)
 
 	//VirtualPath config
-	if server.virtualPath != ""{
+	if server.virtualPath == ""{
 		server.virtualPath = server.ServerConfig().VirtualPath
 	}
 }

--- a/server.go
+++ b/server.go
@@ -206,6 +206,8 @@ func (server *HttpServer) IsOffline() bool {
 // SetVirtualPath set current server's VirtualPath
 func (server *HttpServer) SetVirtualPath(path string){
 	server.virtualPath = path
+	logger.Logger().Debug("DotWeb:HttpServer SetVirtualPath ["+path+"]", LogTarget_HttpServer)
+
 }
 
 // VirtualPath return current server's VirtualPath
@@ -216,6 +218,8 @@ func (server *HttpServer) VirtualPath() string{
 // SetOffline set server offline config
 func (server *HttpServer) SetOffline(offline bool, offlineText string, offlineUrl string) {
 	server.offline = offline
+	logger.Logger().Debug("DotWeb:HttpServer SetOffline ["+strconv.FormatBool(offline)+", " + offlineText +", " + offlineUrl + "]", LogTarget_HttpServer)
+
 }
 
 // IndexPage default index page name


### PR DESCRIPTION
#### Version 1.5.7.3
* New Feature: Add HttpServer.VirtualPath, used to set virtual path when deploy on no root path
* Detail:
  - when set virtual path "/vpath", if set route "/index", it will auto register "vpath/index"
  - in effect on group & route
* 2018-08-24 19:00