### PR TITLE
Version 1.5.7.4 - Bug Fixed

### DIFF
--- a/core/state.go
+++ b/core/state.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"github.com/devfeel/dotweb/framework/sysx"
 )
 
 var GlobalState *ServerStateInfo
@@ -106,6 +107,8 @@ type ServerStateInfo struct {
 //ShowHtmlData show server state data html-string format
 func (state *ServerStateInfo) ShowHtmlData(version string) string {
 	data := "<html><body><div>"
+	data += "HostInfo : " + sysx.GetHostName()
+	data += "<br>"
 	data += "CurrentTime : " + time.Now().Format("2006-01-02 15:04:05")
 	data += "<br>"
 	data += "ServerVersion : " + version

--- a/framework/sysx/sysx.go
+++ b/framework/sysx/sysx.go
@@ -1,0 +1,9 @@
+package sysx
+
+import "os"
+
+// GetHostName get host name
+func GetHostName() string{
+	host, _ := os.Hostname()
+	return host
+}

--- a/router.go
+++ b/router.go
@@ -263,7 +263,6 @@ func (r *router) ServeHTTP(ctx *HttpContext) {
 	}
 
 	// Handle 404
-	ctx.Response().SetStatusCode(http.StatusNotFound)
 	r.server.DotApp.NotFoundHandler(ctx)
 }
 

--- a/version.MD
+++ b/version.MD
@@ -2,8 +2,8 @@
 
 #### Version 1.5.7.4
 * Fixed Bug: Remove auto set NotFound http status when happened 404, if auto set, it will ignore any ContentType set
-* For issue #149 router middleware handle http 404,405. cann`t response content-type:application/json
-* Thanks for @lyw1995
+* For issue #149 router middleware handle http 404,405. cann`t response content-type:application/json, Thanks for @lyw1995
+* Update: Add HostName in State page
 * 2018-08-28 13:00
 
 #### Version 1.5.7.3

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,11 @@
 ## dotweb版本记录：
 
+#### Version 1.5.7.4
+* Fixed Bug: Remove auto set NotFound http status when happened 404, if auto set, it will ignore any ContentType set
+* For issue #149 router middleware handle http 404,405. cann`t response content-type:application/json
+* Thanks for @lyw1995
+* 2018-08-28 13:00
+
 #### Version 1.5.7.3
 * New Feature: Add HttpServer.VirtualPath, used to set virtual path when deploy on no root path
 * Detail:


### PR DESCRIPTION
* Fixed Bug: Remove auto set NotFound http status when happened 404, if auto set, it will ignore any ContentType set
* For issue #149 router middleware handle http 404,405. cann`t response content-type:application/json
* Thanks for @lyw1995
* 2018-08-28 13:00