### PR TITLE
Version 1.5.7.5 - return err from Next()

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -2,7 +2,8 @@ package dotweb
 
 //Global define
 const(
-	Version = "1.5.7.1"
+	// Version current version
+	Version = "1.5.7.5"
 )
 
 //Log define


### PR DESCRIPTION
* Fixed Bug: return err from Next() in RequestLogMiddleware & TimeoutHookMiddleware
* 2018-08-30 10:00