### PR TITLE
Version 1.5.7.6 - Add Renderer.RegisterTemplateFunc

### DIFF
--- a/example/render/main.go
+++ b/example/render/main.go
@@ -14,7 +14,7 @@ func main() {
 	//设置dotserver日志目录
 	app.SetLogPath(file.GetCurrentDirectory())
 
-	//app.SetDevelopmentMode()
+	app.SetDevelopmentMode()
 
 	//设置gzip开关
 	//app.HttpServer.SetEnabledGzip(true)
@@ -24,6 +24,9 @@ func main() {
 
 	//set default template path
 	app.HttpServer.Renderer().SetTemplatePath("d:/gotmp/")
+	app.HttpServer.Renderer().RegisterTemplateFunc("echo", func(x string) interface{}{
+		return "echo:" + x
+	})
 
 	//启动 监控服务
 	//app.SetPProfConfig(true, 8081)

--- a/example/render/testview.html
+++ b/example/render/testview.html
@@ -17,7 +17,7 @@ Sex => {{.user.Sex}}
 <b>Books:</b>
 <br>
  {{range .Books}}
-BookName => {{.Name}}; Size => {{.Size}}
+BookName => {{echo .Name}}; Size => {{.Size}}
 <br>
 {{end}}
 </div>

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,18 @@
 ## dotweb版本记录：
 
+#### Version 1.5.7.6
+* New Feature: Add Renderer.RegisterTemplateFunc, used to register template func in renderer
+* Detail:
+  - now inner support inner func like unescaped
+  - you can view example on example/render
+* Example:
+  ``` golang
+  app.HttpServer.Renderer().RegisterTemplateFunc("echo", func(x string) interface{}{
+  		return "echo:" + x
+  	})
+  ```
+* 2018-09-07
+
 #### Version 1.5.7.5
 * Fixed Bug: return err from Next() in RequestLogMiddleware & TimeoutHookMiddleware
 * 2018-08-30 10:00


### PR DESCRIPTION
#### Version 1.5.7.6
* New Feature: Add Renderer.RegisterTemplateFunc, used to register template func in renderer
* Detail:
  - now inner support inner func like unescaped
  - you can view example on example/render
* Example:
  ``` golang
  app.HttpServer.Renderer().RegisterTemplateFunc("echo", func(x string) interface{}{
  		return "echo:" + x
  	})
  ```
* 2018-09-07