### PR TITLE
Version 1.5.7.6 - Add Renderer.RegisterTemplateFunc

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,7 +3,7 @@ package dotweb
 //Global define
 const(
 	// Version current version
-	Version = "1.5.7.5"
+	Version = "1.5.7.6"
 )
 
 //Log define


### PR DESCRIPTION
#### Version 1.5.7.6
* New Feature: Add Renderer.RegisterTemplateFunc, used to register template func in renderer
* Detail:
  - now inner support inner func like unescaped
  - you can view example on example/render
* Example:
  ``` golang
  app.HttpServer.Renderer().RegisterTemplateFunc("echo", func(x string) interface{}{
  		return "echo:" + x
  	})
  ```
* 2018-09-07