### PR TITLE
#### Version 1.5.7.7

### DIFF
--- a/config/configs.go
+++ b/config/configs.go
@@ -46,6 +46,7 @@ type (
 		EnabledRequestID         bool   `xml:"enabledrequestid,attr"`         //设置是否启用唯一请求ID，默认不开启，开启后使用32位UUID
 		EnabledGzip              bool   `xml:"enabledgzip,attr"`              //是否启用gzip
 		EnabledAutoHEAD          bool   `xml:"enabledautohead,attr"`          //设置是否自动启用Head路由，若设置该项，则会为除Websocket\HEAD外所有路由方式默认添加HEAD路由，默认不开启
+		EnabledAutoOPTIONS       bool   							          //设置是否自动启用Options路由，若设置该项，则会为除Websocket\Options外所有路由方式默认添加Options路由，默认不开启
 		EnabledAutoCORS          bool   `xml:"enabledautocors,attr"`          //设置是否自动跨域支持，若设置，默认“GET, POST, PUT, DELETE, OPTIONS”全部请求均支持跨域
 		EnabledIgnoreFavicon     bool   `xml:"enabledignorefavicon,attr"`     //设置是否忽略favicon.ico请求，若设置，网站将把所有favicon.ico请求直接空返回
 		EnabledBindUseJsonTag    bool   `xml:"enabledbindusejsontag,attr"`    //设置bind是否启用json标签,默认不启用,若设置，bind自动识别json tag,忽略form tag

--- a/consts.go
+++ b/consts.go
@@ -3,7 +3,7 @@ package dotweb
 //Global define
 const(
 	// Version current version
-	Version = "1.5.7.6"
+	Version = "1.5.7.7"
 )
 
 //Log define

--- a/example/router/main.go
+++ b/example/router/main.go
@@ -9,12 +9,12 @@ import (
 
 func main() {
 	//初始化DotServer
-	app := dotweb.New()
+	app := dotweb.Classic(file.GetCurrentDirectory())
 
-	//设置dotserver日志目录
-	app.SetLogPath(file.GetCurrentDirectory())
+	app.SetDevelopmentMode()
 
-	//app.HttpServer.SetEnabledAutoHEAD(true)
+	app.HttpServer.SetEnabledAutoHEAD(true)
+	app.HttpServer.SetEnabledAutoOPTIONS(true)
 
 	//设置路由
 	InitRoute(app.HttpServer)

--- a/router.go
+++ b/router.go
@@ -456,8 +456,22 @@ func (r *router) RegisterRoute(routeMethod string, path string, handle HttpHandl
 	if r.server.ServerConfig().EnabledAutoHEAD {
 		if routeMethod == RouteMethod_HiJack {
 			r.add(RouteMethod_HEAD, realPath, r.wrapRouterHandle(handle, true))
-		} else if routeMethod != RouteMethod_Any {
+			logger.Logger().Debug("DotWeb:Router:RegisterRoute AutoHead success ["+RouteMethod_HEAD+"] ["+realPath+"] ["+handleName+"]", LogTarget_HttpServer)
+		} else if routeMethod != RouteMethod_Any && routeMethod != RouteMethod_HEAD {
 			r.add(RouteMethod_HEAD, realPath, r.wrapRouterHandle(handle, false))
+			logger.Logger().Debug("DotWeb:Router:RegisterRoute AutoHead success ["+RouteMethod_HEAD+"] ["+realPath+"] ["+handleName+"]", LogTarget_HttpServer)
+		}
+	}
+
+	//if set auto-options, add options router
+	//only enabled in hijack\GET\POST\DELETE\PUT\HEAD\PATCH\OPTIONS
+	if r.server.ServerConfig().EnabledAutoOPTIONS {
+		if routeMethod == RouteMethod_HiJack {
+			r.add(RouteMethod_OPTIONS, realPath, r.wrapRouterHandle(handle, true))
+			logger.Logger().Debug("DotWeb:Router:RegisterRoute AutoOPTIONS success ["+RouteMethod_OPTIONS+"] ["+realPath+"] ["+handleName+"]", LogTarget_HttpServer)
+		} else if routeMethod != RouteMethod_Any && routeMethod != RouteMethod_OPTIONS {
+			r.add(RouteMethod_OPTIONS, realPath, r.wrapRouterHandle(handle, false))
+			logger.Logger().Debug("DotWeb:Router:RegisterRoute AutoOPTIONS success ["+RouteMethod_OPTIONS+"] ["+realPath+"] ["+handleName+"]", LogTarget_HttpServer)
 		}
 	}
 	return node

--- a/server.go
+++ b/server.go
@@ -378,6 +378,14 @@ func (server *HttpServer) SetEnabledAutoHEAD(isEnabled bool) {
 	logger.Logger().Debug("DotWeb:HttpServer SetEnabledAutoHEAD ["+strconv.FormatBool(isEnabled)+"]", LogTarget_HttpServer)
 }
 
+// SetEnabledAutoOPTIONS set route use auto options
+// set SetEnabledAutoOPTIONS true or false
+// default is false
+func (server *HttpServer) SetEnabledAutoOPTIONS(isEnabled bool) {
+	server.ServerConfig().EnabledAutoOPTIONS = isEnabled
+	logger.Logger().Debug("DotWeb:HttpServer SetEnabledAutoOPTIONS ["+strconv.FormatBool(isEnabled)+"]", LogTarget_HttpServer)
+}
+
 // SetEnabledRequestID set create unique request id per request
 // set EnabledRequestID true or false
 // default is false

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,24 @@
 ## dotweb版本记录：
 
+#### Version 1.5.7.7
+* New Feature: Add HttpServer.SetEnabledAutoOPTIONS, used to set route use auto options
+* Detail:
+  - ignore auto set if register router is options method
+  - you can view example on example/router
+* Example:
+  ``` golang
+  app.HttpServer.SetEnabledAutoOPTIONS(true)
+  ```
+* Fixed Bug: When use HttpServer.SetEnabledAutoHead, ignore auto set if register router is head method
+* Log output: Add debug log when AutoOPTIONS and AutoHead doing
+* Like:
+  ~~~
+  2018-09-19 15:44:42.8189 [DEBUG] [router.go:437] DotWeb:Router:RegisterRoute success [GET] [/] [main.Index]
+  2018-09-19 15:44:42.8199 [DEBUG] [router.go:462] DotWeb:Router:RegisterRoute AutoHead success [HEAD] [/] [main.Index]
+  2018-09-19 15:44:42.8199 [DEBUG] [router.go:474] DotWeb:Router:RegisterRoute AutoOPTIONS success [OPTIONS] [/] [main.Index]
+  ~~~
+* 2018-09-19 18:00
+
 #### Version 1.5.7.6
 * New Feature: Add Renderer.RegisterTemplateFunc, used to register template func in renderer
 * Detail:


### PR DESCRIPTION
* New Feature: Add HttpServer.SetEnabledAutoOPTIONS, used to set route use auto options
* Detail:
  - ignore auto set if register router is options method
  - you can view example on example/router
* Example:
  ``` golang
  app.HttpServer.SetEnabledAutoOPTIONS(true)
  ```
* Fixed Bug: When use HttpServer.SetEnabledAutoHead, ignore auto set if register router is head method
* Log output: Add debug log when AutoOPTIONS and AutoHead doing
* Like:
  ~~~
  2018-09-19 15:44:42.8189 [DEBUG] [router.go:437] DotWeb:Router:RegisterRoute success [GET] [/] [main.Index]
  2018-09-19 15:44:42.8199 [DEBUG] [router.go:462] DotWeb:Router:RegisterRoute AutoHead success [HEAD] [/] [main.Index]
  2018-09-19 15:44:42.8199 [DEBUG] [router.go:474] DotWeb:Router:RegisterRoute AutoOPTIONS success [OPTIONS] [/] [main.Index]
  ~~~
* 2018-09-19 18:00