### PR TITLE
#### Version 1.5.7.7

### DIFF
--- a/example/router/main.go
+++ b/example/router/main.go
@@ -14,7 +14,7 @@ func main() {
 	app.SetDevelopmentMode()
 
 	app.HttpServer.SetEnabledAutoHEAD(true)
-	app.HttpServer.SetEnabledAutoOPTIONS(true)
+	//app.HttpServer.SetEnabledAutoOPTIONS(true)
 
 	//设置路由
 	InitRoute(app.HttpServer)
@@ -43,5 +43,5 @@ func Any(ctx dotweb.Context) error {
 func InitRoute(server *dotweb.HttpServer) {
 	server.GET("/", Index)
 	server.GET("/d/:x/y", Index)
-	server.GET("/any", Any)
+	server.Any("/any", Any)
 }


### PR DESCRIPTION
* New Feature: Add HttpServer.SetEnabledAutoOPTIONS, used to set route use auto options
* Detail:
  - ignore auto set if register router is options method
  - you can view example on example/router
* Example:
  ``` golang
  app.HttpServer.SetEnabledAutoOPTIONS(true)
  ```
* Fixed Bug: When use HttpServer.SetEnabledAutoHead, ignore auto set if register router is head method
* Log output: Add debug log when AutoOPTIONS and AutoHead doing
* Like:
  ~~~
  2018-09-19 15:44:42.8189 [DEBUG] [router.go:437] DotWeb:Router:RegisterRoute success [GET] [/] [main.Index]
  2018-09-19 15:44:42.8199 [DEBUG] [router.go:462] DotWeb:Router:RegisterRoute AutoHead success [HEAD] [/] [main.Index]
  2018-09-19 15:44:42.8199 [DEBUG] [router.go:474] DotWeb:Router:RegisterRoute AutoOPTIONS success [OPTIONS] [/] [main.Index]
  ~~~
* 2018-09-19 18:00