### PR TITLE
Version 1.5.9 - Add HttpServer.SetEnabledStaticFileMiddleware & Group.ServerFile & Ping Check

### DIFF
--- a/config/configs.go
+++ b/config/configs.go
@@ -50,6 +50,7 @@ type (
 		EnabledAutoCORS          bool   `xml:"enabledautocors,attr"`          //设置是否自动跨域支持，若设置，默认“GET, POST, PUT, DELETE, OPTIONS”全部请求均支持跨域
 		EnabledIgnoreFavicon     bool   `xml:"enabledignorefavicon,attr"`     //设置是否忽略favicon.ico请求，若设置，网站将把所有favicon.ico请求直接空返回
 		EnabledBindUseJsonTag    bool   `xml:"enabledbindusejsontag,attr"`    //设置bind是否启用json标签,默认不启用,若设置，bind自动识别json tag,忽略form tag
+		EnabledStaticFileMiddleware	 bool   								  //The flag which enabled or disabled middleware for static-file route
 		Port                     int    `xml:"port,attr"`                     //端口
 		EnabledTLS               bool   `xml:"enabledtls,attr"`               //是否启用TLS模式
 		TLSCertFile              string `xml:"tlscertfile,attr"`              //TLS模式下Certificate证书文件地址

--- a/dotweb.go
+++ b/dotweb.go
@@ -473,13 +473,9 @@ func (app *DotWeb) initBindMiddleware() {
 		xg := g.(*xGroup)
 		if len(xg.middlewares) <= 0 {
 			continue
-		} else {
-			firstMiddleware := &xMiddleware{}
-			firstMiddleware.SetNext(xg.middlewares[0])
-			xg.middlewares = append([]Middleware{firstMiddleware}, xg.middlewares...)
 		}
 		for fullExpress, _ := range xg.allRouterExpress {
-			expresses := strings.Split(fullExpress, "_")
+			expresses := strings.Split(fullExpress, routerExpressSplit)
 			if len(expresses) < 2 {
 				continue
 			}

--- a/request.go
+++ b/request.go
@@ -12,6 +12,7 @@ type Request struct {
 	*http.Request
 	httpCtx    *HttpContext
 	postBody   []byte
+	realUrl	   string
 	isReadBody bool
 	requestID  string
 }
@@ -175,5 +176,9 @@ func (req *Request) IsAJAX() bool {
 
 // Url get request url
 func (req *Request) Url() string {
-	return req.URL.String()
+	if req.realUrl != ""{
+		return req.realUrl
+	}else{
+		return req.URL.String()
+	}
 }

--- a/server.go
+++ b/server.go
@@ -448,6 +448,12 @@ func (server *HttpServer) SetEnabledDetailRequestData(isEnabled bool) {
 	logger.Logger().Debug("DotWeb:HttpServer SetEnabledDetailRequestData ["+strconv.FormatBool(isEnabled)+"]", LogTarget_HttpServer)
 }
 
+// SetEnabledStaticFileMiddleware set flag which enabled or disabled middleware for static-file route
+func (server *HttpServer) SetEnabledStaticFileMiddleware(isEnabled bool){
+	server.ServerConfig().EnabledStaticFileMiddleware = isEnabled
+	logger.Logger().Debug("DotWeb:HttpServer SetEnabledStaticFileMiddleware ["+strconv.FormatBool(isEnabled)+"]", LogTarget_HttpServer)
+}
+
 // RegisterModule 添加处理模块
 func (server *HttpServer) RegisterModule(module *HttpModule) {
 	server.Modules = append(server.Modules, module)

--- a/version.MD
+++ b/version.MD
@@ -3,7 +3,7 @@
 #### Version 1.5.9
 * New Feature: Add HttpServer.SetEnabledStaticFileMiddleware, used to set flag which enabled or disabled middleware for static-file route
 * Detail:
-  - if set ture, when visit static file route, will use middlewares like other router
+  - if enabled, when visit static file route, will use middlewares like other router
   - the execute order: App -> Group -> Router
   - default is not enabled
 * Example:

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,19 @@
 ## dotweb版本记录：
 
+#### Version 1.5.9
+* New Feature: Add HttpServer.SetEnabledStaticFileMiddleware, used to set flag which enabled or disabled middleware for static-file route
+* Detail:
+  - if set ture, when visit static file route, will use middlewares like other router
+  - the execute order: App -> Group -> Router
+  - default is not enabled
+* Example:
+``` golang
+app.HttpServer.SetEnabledStaticFileMiddleware(true)
+```
+* New Feature: Add Group.ServerFile used to registe static file router in group
+* update dotweb-example/static
+* 2018-10-30 15:00
+
 #### Version 1.5.8
 * New Feature: Add HttpServer.SetBinder, used to set custom Binder on HttpServer
 * Detail:

--- a/version.MD
+++ b/version.MD
@@ -11,6 +11,7 @@
 app.HttpServer.SetEnabledStaticFileMiddleware(true)
 ```
 * New Feature: Add Group.ServerFile used to registe static file router in group
+* New Feature: Add ping check when init redis session, if can not ping successful, it will panic error info, like "panic: redis session [redis] ping error"
 * update dotweb-example/static
 * 2018-10-30 15:00
 


### PR DESCRIPTION
#### Version 1.5.9
* New Feature: Add HttpServer.SetEnabledStaticFileMiddleware, used to set flag which enabled or disabled middleware for static-file route
* Detail:
  - if enabled, when visit static file route, will use middlewares like other router
  - the execute order: App -> Group -> Router
  - default is not enabled
* Example:
``` golang
app.HttpServer.SetEnabledStaticFileMiddleware(true)
```
* New Feature: Add Group.ServerFile used to registe static file router in group
* New Feature: Add ping check when init redis session, if can not ping successful, it will panic error info, like "panic: redis session [redis] ping error"
* update dotweb-example/static
* 2018-10-30 15:00