### PR TITLE
Add Request.RealIP and route.ServerFile support ''/*filepath' or '/*'

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,7 +3,7 @@ package dotweb
 //Global define
 const(
 	// Version current version
-	Version = "1.5.7.7"
+	Version = "1.5.9.1"
 )
 
 //Log define

--- a/example/main.go
+++ b/example/main.go
@@ -93,7 +93,7 @@ func main() {
 
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	ctx.WriteString(ctx.Request().URL.Path)
+	ctx.WriteString(ctx.Request().RemoteIP())
 	//_, err := ctx.WriteStringC(201, "index => ", ctx.RemoteIP(), "我是首页")
 	return nil
 }

--- a/request.go
+++ b/request.go
@@ -149,8 +149,9 @@ func (req *Request) RemoteIP() string {
 	return host
 }
 
-// RealIP returns the first ip from 'X-Forwarded-For' header key
+// RealIP returns the first ip from 'X-Forwarded-For' or 'X-Real-IP' header key
 // if not exists data, returns request.RemoteAddr
+// fixed for #164
 func (req *Request) RealIP() string {
 	if ip := req.Header.Get(HeaderXForwardedFor); ip != "" {
 		return strings.Split(ip, ", ")[0]

--- a/request.go
+++ b/request.go
@@ -3,6 +3,7 @@ package dotweb
 import (
 	"github.com/devfeel/dotweb/framework/crypto/uuid"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -121,16 +122,14 @@ func (req *Request) QueryHeader(key string) string {
 	return req.Header.Get(key)
 }
 
-//Deprecated: Use the PostFormValue instead
-//returns the first value for the named component of the POST
+// Deprecated: Use the PostFormValue instead
+// PostString returns the first value for the named component of the POST
 // or PUT request body. URL query parameters are ignored.
 func (req *Request) PostString(key string) string {
 	return req.PostFormValue(key)
 }
 
-/*
-* 获取post提交的字节数组
- */
+// PostBody returns data from the POST or PUT request body
 func (req *Request) PostBody() []byte {
 	if !req.isReadBody {
 		bts, err := ioutil.ReadAll(req.Body)
@@ -144,19 +143,26 @@ func (req *Request) PostBody() []byte {
 	return req.postBody
 }
 
-//RemoteAddr to an "IP" address
+// RemoteIP RemoteAddr to an "IP" address
 func (req *Request) RemoteIP() string {
-	fullIp := req.Request.RemoteAddr
-	//special: if run in win10, localIp will be like "[::]:port"
-	//fixed for #20 cann't get RemoteIP and RemoteAddr in win10
-	lastFlagIndex := strings.LastIndex(fullIp, ":")
-	if lastFlagIndex >= 0 {
-		return fullIp[:lastFlagIndex]
-	}
-	return fullIp
+	host, _, _ := net.SplitHostPort(req.RemoteAddr)
+	return host
 }
 
-//RemoteAddr to an "IP:port" address
+// RealIP returns the first ip from 'X-Forwarded-For' header key
+// if not exists data, returns request.RemoteAddr
+func (req *Request) RealIP() string {
+	if ip := req.Header.Get(HeaderXForwardedFor); ip != "" {
+		return strings.Split(ip, ", ")[0]
+	}
+	if ip := req.Header.Get(HeaderXRealIP); ip != "" {
+		return ip
+	}
+	host, _, _ := net.SplitHostPort(req.RemoteAddr)
+	return host
+}
+
+// FullRemoteIP RemoteAddr to an "IP:port" address
 func (req *Request) FullRemoteIP() string {
 	fullIp := req.Request.RemoteAddr
 	return fullIp

--- a/request.go
+++ b/request.go
@@ -122,9 +122,9 @@ func (req *Request) QueryHeader(key string) string {
 	return req.Header.Get(key)
 }
 
-// Deprecated: Use the PostFormValue instead
 // PostString returns the first value for the named component of the POST
 // or PUT request body. URL query parameters are ignored.
+// Deprecated: Use the PostFormValue instead
 func (req *Request) PostString(key string) string {
 	return req.PostFormValue(key)
 }

--- a/router.go
+++ b/router.go
@@ -498,13 +498,20 @@ func (r *router) RegisterRoute(routeMethod string, path string, handle HttpHandl
 }
 
 // ServerFile is a shortcut for router.ServeFiles(path, filepath)
+// simple demo:server.ServerFile("/src/*", "/var/www")
 // simple demo:server.ServerFile("/src/*filepath", "/var/www")
 func (r *router) ServerFile(path string, fileroot string) RouterNode {
 	realPath := r.server.VirtualPath() + path
 	routeMethod := RouteMethod_GET
 	node := &Node{}
+	if len(realPath) < 2{
+		panic("path length must be greater than or equal to 2")
+	}
+	if realPath[len(realPath)-2:] == "/*"{
+		realPath = realPath + "filepath"
+	}
 	if len(realPath) < 10 || realPath[len(realPath)-10:] != "/*filepath" {
-		panic("path must end with /*filepath in path '" + realPath + "'")
+		panic("path must end with /*filepath or /* in path '" + realPath + "'")
 	}
 	var root http.FileSystem
 	root = http.Dir(fileroot)

--- a/router.go
+++ b/router.go
@@ -507,7 +507,7 @@ func (r *router) ServerFile(path string, fileroot string) RouterNode {
 	if len(realPath) < 2{
 		panic("path length must be greater than or equal to 2")
 	}
-	if realPath[len(realPath)-2:] == "/*"{
+	if realPath[len(realPath)-2:] == "/*"{ //fixed for #125
 		realPath = realPath + "filepath"
 	}
 	if len(realPath) < 10 || realPath[len(realPath)-10:] != "/*filepath" {

--- a/version.MD
+++ b/version.MD
@@ -1,8 +1,8 @@
 ## dotweb版本记录：
 
 #### Version 1.5.9.1
-* New Feature: Add Request.RealIP used to returns the first ip from 'X-Forwarded-For' header key, fixed for #164
-* New Feature: route.ServerFile support '*filepath' or '/*', to simplify register static file router
+* New Feature: Add Request.RealIP used to returns the first ip from 'X-Forwarded-For' or 'X-Real-IP' header key, fixed for #164
+* New Feature: route.ServerFile support '*filepath' or '/*', to simplify register static file router, fixed for #125
 * Example:
 ``` golang
 app.HttpServer.ServerFile("/*", "D:/gotmp")

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,15 @@
 ## dotweb版本记录：
 
+#### Version 1.5.9.1
+* New Feature: Add Request.RealIP used to returns the first ip from 'X-Forwarded-For' header key, fixed for #164
+* New Feature: route.ServerFile support '*filepath' or '/*', to simplify register static file router
+* Example:
+``` golang
+app.HttpServer.ServerFile("/*", "D:/gotmp")
+```
+* update example/main
+* 2018-12-03 15:00
+
 #### Version 1.5.9
 * New Feature: Add HttpServer.SetEnabledStaticFileMiddleware, used to set flag which enabled or disabled middleware for static-file route
 * Detail:


### PR DESCRIPTION
#### Version 1.5.9.1
* New Feature: Add Request.RealIP used to returns the first ip from 'X-Forwarded-For' or 'X-Real-IP' header key, fixed for #164
* New Feature: route.ServerFile support '*filepath' or '/*', to simplify register static file router, fixed for #125
* Example:
``` golang
app.HttpServer.ServerFile("/*", "D:/gotmp")
```
* update example/main
* 2018-12-03 15:00