### PR TITLE
Fixed Bug & support http2 Push

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ go get -u github.com/devfeel/dotweb
 
 ## 2. Getting Started
 ```go
-func StartServer() error {
+func main() {
 	//init DotApp
 	app := dotweb.New()
 	//set log path
@@ -35,7 +35,7 @@ func StartServer() error {
 	})
 	//begin server
 	err := app.StartServer(80)
-	return err
+    fmt.Println("dotweb.StartServer error => ", err)
 }
 
 ```

--- a/example/middleware/main.go
+++ b/example/middleware/main.go
@@ -20,6 +20,8 @@ func main() {
 	//开启development模式
 	app.SetDevelopmentMode()
 
+	app.UseTimeoutHook(dotweb.DefaultTimeoutHookHandler, time.Second * 10)
+
 	exAccessFmtLog := NewAccessFmtLog("appex")
 	exAccessFmtLog.Exclude("/index")
 	exAccessFmtLog.Exclude("/v1/machines/queryIP/:IP")

--- a/request.go
+++ b/request.go
@@ -179,7 +179,7 @@ func (req *Request) Path() string {
 
 // IsAJAX returns if it is a ajax request
 func (req *Request) IsAJAX() bool {
-	return req.Header.Get(HeaderXRequestedWith) == "XMLHttpRequest"
+	return strings.Contains(req.Header.Get(HeaderXRequestedWith), "XMLHttpRequest")
 }
 
 // Url get request url

--- a/response.go
+++ b/response.go
@@ -169,3 +169,9 @@ func (w *gzipResponseWriter) Flush() {
 func (w *gzipResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return w.ResponseWriter.(http.Hijacker).Hijack()
 }
+
+
+// Push support http2 Push
+func (r *Response) Push(target string, opts *http.PushOptions) error {
+	return r.writer.(http.Pusher).Push(target, opts)
+}

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,30 @@
 ## dotweb版本记录：
 
+#### Version 1.5.9.5
+* Fixed Bug: Request.IsAJAX check X-Requested-With Contains XMLHttpRequest
+* New Feature: Response support http2 Push
+* How To:
+  - how to query slow response in your app?
+  ~~~go
+  func main() {
+  	app := dotweb.Classic("/home/logs/wwwroot/")
+
+  	// deal slow response, use default handler
+  	// default Handler will write timeout-response in dotweb's log file
+  	// also you can implement your own handlers, like write logs with http api
+  	app.UseTimeoutHook(dotweb.DefaultTimeoutHookHandler, time.Second * 10)
+
+  	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
+  		return ctx.WriteString("welcome to my first web!")
+  	})
+
+  	//begin server
+  	err := app.StartServer(80)
+      fmt.Println("dotweb.StartServer error => ", err)
+  }
+  ~~~
+* 2019-01-02 18:00
+
 #### Version 1.5.9.4
 * Fix UT in cache/runtime
 * Remove invalid lock in cache/runtime


### PR DESCRIPTION
* Fixed Bug: Request.IsAJAX check X-Requested-With Contains XMLHttpRequest
* New Feature: Response support http2 Push
* How To:
  - how to query slow response in your app?
  ~~~go
  func main() {
  	app := dotweb.Classic("/home/logs/wwwroot/")

  	// deal slow response, use default handler
  	// default Handler will write timeout-response in dotweb's log file
  	// also you can implement your own handlers, like write logs with http api
  	app.UseTimeoutHook(dotweb.DefaultTimeoutHookHandler, time.Second * 10)

  	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
  		return ctx.WriteString("welcome to my first web!")
  	})

  	//begin server
  	err := app.StartServer(80)
      fmt.Println("dotweb.StartServer error => ", err)
  }
  ~~~
* 2019-01-02 18:00