### PR TITLE
add RegisterServerFile & support EnabledAutoHEAD\EnabledAutoOPTIONS in ServerFile 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
 	})
 	//begin server
 	err := app.StartServer(80)
-    fmt.Println("dotweb.StartServer error => ", err)
+	fmt.Println("dotweb.StartServer error => ", err)
 }
 
 ```

--- a/server.go
+++ b/server.go
@@ -328,10 +328,16 @@ func (server *HttpServer) DELETE(path string, handle HttpHandle) RouterNode {
 	return server.Router().DELETE(path, handle)
 }
 
-// ServerFile is a shortcut for router.ServeFiles(path, filepath)
+// ServerFile a shortcut for router.ServeFiles(path, fileRoot)
 // simple demo:server.ServerFile("/src/*filepath", "/var/www")
-func (server *HttpServer) ServerFile(path string, fileroot string) RouterNode {
-	return server.Router().ServerFile(path, fileroot)
+func (server *HttpServer) ServerFile(path string, fileRoot string) RouterNode {
+	return server.Router().ServerFile(path, fileRoot)
+}
+
+// RegisterServerFile a shortcut for router.RegisterServerFile(routeMethod, path, fileRoot)
+// simple demo:server.RegisterServerFile(RouteMethod_GET, "/src/*filepath", "/var/www")
+func (server *HttpServer) RegisterServerFile(routeMethod string, path string, fileRoot string) RouterNode {
+	return server.Router().RegisterServerFile(routeMethod, path, fileRoot)
 }
 
 // HiJack is a shortcut for router.HiJack(path, handle)

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,35 @@
 ## dotweb版本记录：
 
+#### Version 1.5.9.6
+* New Feature: HttpServer & Router add RegisterServerFile use to register ServerFile router with routeMethod method on http.FileServer
+* Update: ServerFile add support for EnabledAutoHEAD\EnabledAutoOPTIONS
+* Detail:
+    - when use ServerFile, default routeMethod is GET
+    - you can use RegisterServerFile specify other HttpMethod, like "POST"
+* Example:
+``` golang
+	server.RegisterServerFile(dotweb.RouteMethod_POST, "/dst/*", "/home/www/")
+```
+* How To:
+  - how to add support "HEAD" method for all requests in your httpserver?
+  ~~~go
+  func main() {
+  	app := dotweb.Classic("/home/logs/wwwroot/")
+
+    // if use this, all router will auto add "HEAD" method support
+    // default is false
+    app.HttpServer.SetEnabledAutoHEAD(true)
+
+  	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
+  		return ctx.WriteString("welcome to my first web!")
+  	})
+
+  	err := app.StartServer(80)
+      fmt.Println("dotweb.StartServer error => ", err)
+  }
+  ~~~
+* 2019-01-03 10:00
+
 #### Version 1.5.9.5
 * Fixed Bug: Request.IsAJAX check X-Requested-With Contains XMLHttpRequest
 * New Feature: Response support http2 Push


### PR DESCRIPTION
* New Feature: HttpServer & Router add RegisterServerFile use to register ServerFile router with routeMethod method on http.FileServer
* Update: ServerFile add support for EnabledAutoHEAD\EnabledAutoOPTIONS
* Detail:
    - when use ServerFile, default routeMethod is GET
    - you can use RegisterServerFile specify other HttpMethod, like "POST"
* Example:
``` golang
	server.RegisterServerFile(dotweb.RouteMethod_POST, "/dst/*", "/home/www/")
```
* How To:
  - how to add support "HEAD" method for all requests in your httpserver?
  ~~~go
  func main() {
  	app := dotweb.Classic("/home/logs/wwwroot/")

    // if use this, all router will auto add "HEAD" method support
    // default is false
    app.HttpServer.SetEnabledAutoHEAD(true)

  	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
  		return ctx.WriteString("welcome to my first web!")
  	})

  	err := app.StartServer(80)
      fmt.Println("dotweb.StartServer error => ", err)
  }
  ~~~
* 2019-01-03 10:00