### PR TITLE
Fix Bug for #184 & Important: will remove ServerConfig().EnabledAutoCORS on version 1.6

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -1,10 +1,6 @@
 package dotweb
 
 import (
-	"compress/gzip"
-	"io"
-	"net/http"
-	"net/url"
 	"strconv"
 
 	"github.com/devfeel/dotweb/feature"
@@ -25,63 +21,4 @@ func (f *xFeatureTools) SetCROSConfig(ctx *HttpContext, c *feature.CROSConfig) {
 	ctx.Response().SetHeader(HeaderAccessControlAllowHeaders, c.AllowedHeaders)
 	ctx.Response().SetHeader(HeaderAccessControlAllowCredentials, strconv.FormatBool(c.AllowCredentials))
 	ctx.Response().SetHeader(HeaderP3P, c.AllowedP3P)
-}
-
-// set CROS config on HttpContext
-func (f *xFeatureTools) SetSession(httpCtx *HttpContext) {
-	sessionId, err := httpCtx.HttpServer().GetSessionManager().GetClientSessionID(httpCtx.Request().Request)
-	if err == nil && sessionId != "" {
-		httpCtx.sessionID = sessionId
-	} else {
-		httpCtx.sessionID = httpCtx.HttpServer().GetSessionManager().NewSessionID()
-		cookie := &http.Cookie{
-			Name:  httpCtx.HttpServer().sessionManager.StoreConfig().CookieName,
-			Value: url.QueryEscape(httpCtx.SessionID()),
-			Path:  "/",
-		}
-		httpCtx.SetCookie(cookie)
-	}
-}
-
-func (f *xFeatureTools) SetGzip(httpCtx *HttpContext) {
-	gw, err := gzip.NewWriterLevel(httpCtx.Response().Writer(), DefaultGzipLevel)
-	if err != nil {
-		panic("use gzip error -> " + err.Error())
-	}
-	grw := &gzipResponseWriter{Writer: gw, ResponseWriter: httpCtx.Response().Writer()}
-	httpCtx.Response().reset(grw)
-	httpCtx.Response().SetHeader(HeaderContentEncoding, gzipScheme)
-}
-
-// doFeatures do features...
-func (f *xFeatureTools) InitFeatures(server *HttpServer, httpCtx *HttpContext) {
-
-	// gzip
-	if server.ServerConfig().EnabledGzip {
-		FeatureTools.SetGzip(httpCtx)
-	}
-
-	// session
-	// if exists client-sessionid, use it
-	// if not exists client-sessionid, new one
-	if server.SessionConfig().EnabledSession {
-		FeatureTools.SetSession(httpCtx)
-	}
-
-	// CROS handling
-	if server.Features.CROSConfig != nil {
-		c := server.Features.CROSConfig
-		if c.EnabledCROS {
-			FeatureTools.SetCROSConfig(httpCtx, c)
-		}
-	}
-
-}
-
-func (f *xFeatureTools) ReleaseFeatures(server *HttpServer, httpCtx *HttpContext) {
-	if server.ServerConfig().EnabledGzip {
-		var w io.Writer
-		w = httpCtx.Response().Writer().(*gzipResponseWriter).Writer
-		w.(*gzip.Writer).Close()
-	}
 }

--- a/router.go
+++ b/router.go
@@ -275,9 +275,6 @@ func (r *router) wrapRouterHandle(handler HttpHandle, isHijack bool) RouterHandl
 	return func(httpCtx *HttpContext) {
 		httpCtx.handler = handler
 
-		// do features
-		FeatureTools.InitFeatures(r.server, httpCtx)
-
 		// hijack handling
 		if isHijack {
 			_, hijack_err := httpCtx.Hijack()
@@ -315,8 +312,6 @@ func (r *router) wrapRouterHandle(handler HttpHandle, isHijack bool) RouterHandl
 				// Increment error count
 				core.GlobalState.AddErrorCount(httpCtx.Request().Path(), fmt.Errorf("%v", err), 1)
 			}
-
-			FeatureTools.ReleaseFeatures(r.server, httpCtx)
 
 			// cancle Context
 			if httpCtx.cancle != nil {

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,12 @@
 ## dotweb版本记录：
 
+
+#### Version 1.5.9.9
+* Fix Bug for #184 ServerFile不能正确获取SessionID()
+* Remove Init Session & Gzip in feature.go
+* Important: We will remove feature.go in dotweb, so will remove ServerConfig().EnabledAutoCORS.
+* 2019-01-28 12:00
+
 #### Version 1.5.9.8
 * New Feature: Fix UT and add scripts for UT
 * Detail:


### PR DESCRIPTION
* Fix Bug for #184 ServerFile不能正确获取SessionID()
* Remove Init Session & Gzip in feature.go
* Important: We will remove feature.go in dotweb, so will remove ServerConfig().EnabledAutoCORS on version 1.6.
* 2019-01-28 12:00