### PR TITLE
Add RouterNode.Path()

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -87,3 +87,9 @@ const (
 	HeaderContentSecurityPolicy   = "Content-Security-Policy"
 	HeaderXCSRFToken              = "X-CSRF-Token"
 )
+
+
+const(
+	HeaderRequestID = "d_request_id"
+	HeaderResponseTime = "d_response_time"
+)

--- a/example/router/main.go
+++ b/example/router/main.go
@@ -33,7 +33,7 @@ func main() {
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
 	flag := ctx.HttpServer().Router().MatchPath(ctx, "/d/:x/y")
-	return ctx.WriteString("index - " + ctx.Request().Method + " - " + fmt.Sprint(flag))
+	return ctx.WriteString("index - " + ctx.Request().Method + " - " + ctx.RouterNode().Path() + " - " + fmt.Sprint(flag))
 }
 
 func Any(ctx dotweb.Context) error {

--- a/request.go
+++ b/request.go
@@ -9,10 +9,6 @@ import (
 )
 
 
-const(
-	HeaderRequestID = "d_request_id"
-)
-
 type Request struct {
 	*http.Request
 	httpCtx    *HttpContext

--- a/router.go
+++ b/router.go
@@ -89,6 +89,7 @@ type (
 		AppMiddlewares() []Middleware
 		GroupMiddlewares() []Middleware
 		Middlewares() []Middleware
+		Path() string
 		Node() *Node
 	}
 

--- a/tree.go
+++ b/tree.go
@@ -74,18 +74,22 @@ func (n *Node) Use(m ...Middleware) *Node {
 	return n
 }
 
+// AppMiddlewares return AppMiddlewares
 func (n *Node) AppMiddlewares() []Middleware {
 	return n.appMiddlewares
 }
 
+// GroupMiddlewares return GroupMiddlewares
 func (n *Node) GroupMiddlewares() []Middleware {
 	return n.groupMiddlewares
 }
 
+// Middlewares return middlewares
 func (n *Node) Middlewares() []Middleware {
 	return n.middlewares
 }
 
+// Path return full path in node
 func (n *Node) Path() string{
 	return n.fullPath
 }

--- a/tree.go
+++ b/tree.go
@@ -86,6 +86,10 @@ func (n *Node) Middlewares() []Middleware {
 	return n.middlewares
 }
 
+func (n *Node) Path() string{
+	return n.fullPath
+}
+
 func (n *Node) Node() *Node {
 	return n
 }

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,31 @@
 ## dotweb版本记录：
 
+#### Version 1.6.1
+* New Feature: RouterNode add RouterNode.Path() to get routing path for the request
+* Detail:
+    - you can use ctx.RouterNode().Path() to get routing path for the request
+    - you can use ctx.HttpServer().Router().MatchPath to match request and routing path
+* Demo:
+  ~~~go
+  func main() {
+  	app := dotweb.Classic("/home/logs/wwwroot/")
+
+    // if use this, all router will auto add "HEAD" method support
+    // default is false
+    app.HttpServer.SetEnabledAutoHEAD(true)
+
+  	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
+  	    flag := ctx.HttpServer().Router().MatchPath(ctx, "/index")
+  		return ctx.WriteString("welcome to my first web!" + ctx.RouterNode().Path() + " - " + fmt.Sprint(flag))
+  	})
+
+  	err := app.StartServer(80)
+      fmt.Println("dotweb.StartServer error => ", err)
+  }
+  ~~~
+* 2019-02-12 16:00
+
+
 #### Version 1.6
 * Remove: remove all features in dotweb!
 * Remove: remove ServerConfig().EnabledAutoCORS.


### PR DESCRIPTION
* New Feature: RouterNode add RouterNode.Path() to get routing path for the request
* Detail:
    - you can use ctx.RouterNode().Path() to get routing path for the request
    - you can use ctx.HttpServer().Router().MatchPath to match request and routing path
* Demo:
  ~~~go
  func main() {
  	app := dotweb.Classic("/home/logs/wwwroot/")

    // if use this, all router will auto add "HEAD" method support
    // default is false
    app.HttpServer.SetEnabledAutoHEAD(true)

  	app.HttpServer.GET("/index", func(ctx dotweb.Context) error{
  	    flag := ctx.HttpServer().Router().MatchPath(ctx, "/index")
  		return ctx.WriteString("welcome to my first web!" + ctx.RouterNode().Path() + " - " + fmt.Sprint(flag))
  	})

  	err := app.StartServer(80)
      fmt.Println("dotweb.StartServer error => ", err)
  }
  ~~~
* 2019-02-12 16:00