### PR TITLE
Bug fixed for cryptos.GetRandString

### DIFF
--- a/framework/crypto/cryptos.go
+++ b/framework/crypto/cryptos.go
@@ -2,10 +2,9 @@ package cryptos
 
 import (
 	"crypto/md5"
-	"crypto/rand"
-	"encoding/base64"
+	"math/rand"
 	"encoding/hex"
-	"io"
+	"time"
 )
 
 // GetMd5String compute the md5 sum as string
@@ -16,11 +15,12 @@ func GetMd5String(s string) string {
 }
 
 // GetRandString returns randominzed string with given length
-func GetRandString(len int) string {
-	b := make([]byte, len)
-
-	if _, err := io.ReadFull(rand.Reader, b); err != nil {
-		return ""
+func GetRandString(length int) string {
+	bytes := []byte("0123456789abcdefghijklmnopqrstuvwxyz")
+	result := []byte{}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < length; i++ {
+		result = append(result, bytes[r.Intn(len(bytes))])
 	}
-	return GetMd5String(base64.URLEncoding.EncodeToString(b))
+	return string(result)
 }

--- a/framework/crypto/cryptos_test.go
+++ b/framework/crypto/cryptos_test.go
@@ -14,3 +14,9 @@ func Test_GetMd5String_1(t *testing.T) {
 	t.Log("GetMd5String:", md5str)
 	test.Equal(t, "25f9e794323b453885f5181f1b624d0b", md5str)
 }
+
+func Test_GetRandString(t *testing.T) {
+	randStr := GetRandString(12)
+	t.Log("GetRandString:", randStr)
+	test.Equal(t, 12, len(randStr))
+}

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,17 @@
 ## dotweb版本记录：
 
+#### Version 1.6.2
+* Bug fixed: cryptos.GetRandString used to returns randominzed string with given length
+* Detail:
+    - default character set is "0123456789abcdefghijklmnopqrstuvwxyz"
+* Demo:
+  ~~~go
+  func main() {
+      fmt.Println(cryptos.GetRandString(10))
+  }
+  ~~~
+* 2019-02-20 14:00
+
 #### Version 1.6.1
 * New Feature: RouterNode add RouterNode.Path() to get routing path for the request
 * Detail:


### PR DESCRIPTION
* Bug fixed: cryptos.GetRandString used to returns randominzed string with given length
* Detail:
    - default character set is "0123456789abcdefghijklmnopqrstuvwxyz"
* Demo:
  ~~~go
  func main() {
      fmt.Println(cryptos.GetRandString(10))
  }
  ~~~
* 2019-02-20 14:00