### PR TITLE
#### Version 1.6.3

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -34,7 +34,7 @@ type AppLog interface {
 
 var (
 	DefaultLogPath        string
-	DefaultEnabledLog     bool = true
+	DefaultEnabledLog     bool = false
 	DefaultEnabledConsole bool = false
 )
 


### PR DESCRIPTION
* Architecture: move logger.Logger() to DotWeb.Logger()
* Architecture: add HttpServer.Logger who is a shortcut for DotWeb.Logger()
* Architecture: remove logger.Logger()
* How to use dotweb.Logger in your app:
  ~~~go
  func TestLog(ctx dotweb.Context) error {
  	ctx.HttpServer().Logger().Info(dotweb.LogTarget_Default, "test log")
  	return ctx.WriteString("log page")
  }
  ~~~
* 2019-06-13 12:00