### PR TITLE
Version 1.6.5 - add dotweb.StateInfo() & remove valueNodePool

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,7 +3,7 @@ package dotweb
 // Global define
 const (
 	// Version current version
-	Version = "1.6.4"
+	Version = "1.6.5"
 )
 
 // Log define

--- a/core/state.go
+++ b/core/state.go
@@ -12,8 +12,6 @@ import (
 	"github.com/devfeel/dotweb/framework/sysx"
 )
 
-var GlobalState *ServerStateInfo
-
 const (
 	minuteTimeLayout        = "200601021504"
 	dateTimeLayout          = "2006-01-02 15:04:05"
@@ -21,8 +19,9 @@ const (
 	defaultCheckTimeMinutes = 10
 )
 
-func init() {
-	GlobalState = &ServerStateInfo{
+// NewServerStateInfo return ServerStateInfo which is init
+func NewServerStateInfo() *ServerStateInfo {
+	state := &ServerStateInfo{
 		ServerStartTime:      time.Now(),
 		TotalRequestCount:    0,
 		TotalErrorCount:      0,
@@ -48,8 +47,9 @@ func init() {
 			},
 		},
 	}
-	go GlobalState.handleInfo()
-	go time.AfterFunc(time.Duration(defaultCheckTimeMinutes)*time.Minute, GlobalState.checkAndRemoveIntervalData)
+	go state.handleInfo()
+	go time.AfterFunc(time.Duration(defaultCheckTimeMinutes)*time.Minute, state.checkAndRemoveIntervalData)
+	return state
 }
 
 type pool struct {

--- a/dotweb.go
+++ b/dotweb.go
@@ -41,6 +41,7 @@ type (
 		IDGenerater             IdGenerate
 		globalUniqueID          string
 		appLog                  logger.AppLog
+		serverStateInfo         *core.ServerStateInfo
 	}
 
 	// ExceptionHandle supports exception handling
@@ -87,6 +88,7 @@ func New() *DotWeb {
 		middlewareMap:   make(map[string]MiddlewareFunc),
 		middlewareMutex: new(sync.RWMutex),
 		StartMode:       StartMode_New,
+		serverStateInfo: core.NewServerStateInfo(),
 	}
 	// set default run mode = RunMode_Production
 	app.Config.App.RunMode = RunMode_Production
@@ -133,6 +135,11 @@ func ClassicWithConf(config *config.Config) *DotWeb {
 // Logger return app's logger
 func (app *DotWeb) Logger() logger.AppLog {
 	return app.appLog
+}
+
+// StateInfo return app's ServerStateInfo
+func (app *DotWeb) StateInfo() *core.ServerStateInfo {
+	return app.serverStateInfo
 }
 
 // RegisterMiddlewareFunc register middleware with given name & middleware
@@ -386,7 +393,7 @@ func (app *DotWeb) initAppConfig() {
 
 	// detailed request metrics
 	if config.Server.EnabledDetailRequestData {
-		core.GlobalState.EnabledDetailRequestData = config.Server.EnabledDetailRequestData
+		app.StateInfo().EnabledDetailRequestData = config.Server.EnabledDetailRequestData
 	}
 }
 

--- a/dotweb_sysgroup.go
+++ b/dotweb_sysgroup.go
@@ -1,7 +1,6 @@
 package dotweb
 
 import (
-	"github.com/devfeel/dotweb/core"
 	jsonutil "github.com/devfeel/dotweb/framework/json"
 	"runtime"
 	"runtime/debug"
@@ -43,14 +42,14 @@ func showIntervalData(ctx Context) error {
 
 	d := new(data)
 	d.Time = queryKey
-	d.RequestCount = core.GlobalState.QueryIntervalRequestData(queryKey)
-	d.ErrorCount = core.GlobalState.QueryIntervalErrorData(queryKey)
+	d.RequestCount = ctx.HttpServer().StateInfo().QueryIntervalRequestData(queryKey)
+	d.ErrorCount = ctx.HttpServer().StateInfo().QueryIntervalErrorData(queryKey)
 	return ctx.WriteJson(d)
 }
 
 // snow server status
 func showServerState(ctx Context) error {
-	return ctx.WriteHtml(core.GlobalState.ShowHtmlData(Version, ctx.HttpServer().DotApp.GlobalUniqueID()))
+	return ctx.WriteHtml(ctx.HttpServer().StateInfo().ShowHtmlData(Version, ctx.HttpServer().DotApp.GlobalUniqueID()))
 }
 
 // query server information
@@ -58,7 +57,7 @@ func showQuery(ctx Context) error {
 	querykey := ctx.GetRouterName("key")
 	switch querykey {
 	case "state":
-		return ctx.WriteString(jsonutil.GetJsonString(core.GlobalState))
+		return ctx.WriteString(jsonutil.GetJsonString(ctx.HttpServer().StateInfo()))
 	case "":
 		return ctx.WriteString("please input key")
 	default:

--- a/router.go
+++ b/router.go
@@ -37,7 +37,6 @@ const (
 
 var (
 	HttpMethodMap map[string]string
-	valueNodePool sync.Pool
 )
 
 func init() {
@@ -52,12 +51,6 @@ func init() {
 	HttpMethodMap["DELETE"] = RouteMethod_DELETE
 	HttpMethodMap["HIJACK"] = RouteMethod_HiJack
 	HttpMethodMap["WEBSOCKET"] = RouteMethod_WebSocket
-
-	valueNodePool = sync.Pool{
-		New: func() interface{} {
-			return &ValueNode{}
-		},
-	}
 
 }
 

--- a/router.go
+++ b/router.go
@@ -309,7 +309,7 @@ func (r *router) wrapRouterHandle(handler HttpHandle, isHijack bool) RouterHandl
 				}
 
 				// Increment error count
-				core.GlobalState.AddErrorCount(httpCtx.Request().Path(), fmt.Errorf("%v", err), 1)
+				r.server.StateInfo().AddErrorCount(httpCtx.Request().Path(), fmt.Errorf("%v", err), 1)
 			}
 
 			// cancle Context
@@ -340,7 +340,7 @@ func (r *router) wrapRouterHandle(handler HttpHandle, isHijack bool) RouterHandl
 			if r.server.DotApp.ExceptionHandler != nil {
 				r.server.DotApp.ExceptionHandler(httpCtx, ctxErr)
 				// increment error count
-				core.GlobalState.AddErrorCount(httpCtx.Request().Path(), ctxErr, 1)
+				r.server.StateInfo().AddErrorCount(httpCtx.Request().Path(), ctxErr, 1)
 			}
 		}
 
@@ -359,7 +359,7 @@ func (r *router) wrapFileHandle(fileHandler http.Handler) RouterHandle {
 			if ctxErr != nil {
 				if r.server.DotApp.ExceptionHandler != nil {
 					r.server.DotApp.ExceptionHandler(httpCtx, ctxErr)
-					core.GlobalState.AddErrorCount(httpCtx.Request().Path(), ctxErr, 1)
+					r.server.StateInfo().AddErrorCount(httpCtx.Request().Path(), ctxErr, 1)
 				}
 			}
 		} else {
@@ -637,7 +637,7 @@ func (r *router) wrapWebSocketHandle(handler HttpHandle) websocket.Handler {
 				r.server.Logger().Error(logString, LogTarget_HttpServer)
 
 				// increment error count
-				core.GlobalState.AddErrorCount(httpCtx.Request().Path(), fmt.Errorf("%v", err), 1)
+				r.server.StateInfo().AddErrorCount(httpCtx.Request().Path(), fmt.Errorf("%v", err), 1)
 			}
 			timetaken := int64(time.Now().Sub(startTime) / time.Millisecond)
 			// HttpServer Logging

--- a/server.go
+++ b/server.go
@@ -142,13 +142,13 @@ func (server *HttpServer) ListenAndServeTLS(addr string, certFile, keyFile strin
 
 // ServeHTTP make sure request can be handled correctly
 func (server *HttpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	core.GlobalState.AddCurrentRequest(1)
-	defer core.GlobalState.SubCurrentRequest(1)
+	server.StateInfo().AddCurrentRequest(1)
+	defer server.StateInfo().SubCurrentRequest(1)
 
 	// special handling for websocket and debugging
 	if checkIsWebSocketRequest(req) {
 		http.DefaultServeMux.ServeHTTP(w, req)
-		core.GlobalState.AddRequestCount(req.URL.Path, defaultHttpCode, 1)
+		server.StateInfo().AddRequestCount(req.URL.Path, defaultHttpCode, 1)
 	} else {
 		// setup header
 		w.Header().Set(HeaderServer, DefaultServerName)
@@ -175,7 +175,7 @@ func (server *HttpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 					module.OnEndRequest(httpCtx)
 				}
 			}
-			core.GlobalState.AddRequestCount(httpCtx.Request().Path(), httpCtx.Response().HttpCode(), 1)
+			server.StateInfo().AddRequestCount(httpCtx.Request().Path(), httpCtx.Response().HttpCode(), 1)
 
 			releaseHttpContext(server, httpCtx)
 		}
@@ -270,8 +270,14 @@ func (server *HttpServer) GetSessionManager() *session.SessionManager {
 	return server.sessionManager
 }
 
+// Logger is a shortcut for dotweb.Logger
 func (server *HttpServer) Logger() logger.AppLog {
 	return server.DotApp.Logger()
+}
+
+// StateInfo is a shortcut for dotweb.StateInfo
+func (server *HttpServer) StateInfo() *core.ServerStateInfo {
+	return server.DotApp.serverStateInfo
 }
 
 // Router get router interface in server

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,14 @@
 ## dotweb版本记录：
 
+#### Version 1.6.5
+* Architecture: move core.GlobalState to dotweb.StateInfo()
+* Architecture: add HttpServer.StateInfo() who is a shortcut for DotWeb.StateInfo()
+* Remove: remove unused property valueNodePool in router
+* About dotweb.StateInfo:
+    - you can use ctx.HttpServer().StateInfo() to get this object
+    - you can visit /virtualPath/dotweb/state to list all state info
+* 2019-06-26 08:00
+
 #### Version 1.6.4
 * Architecture: add dotweb_sysgroup.go to implement IncludeDotwebGroup
 * New Feature: add /virtualPath/dotweb/routers to list all router express


### PR DESCRIPTION
#### Version 1.6.5
* Architecture: move core.GlobalState to dotweb.StateInfo()
* Architecture: add HttpServer.StateInfo() who is a shortcut for DotWeb.StateInfo()
* Remove: remove unused property valueNodePool in router
* About dotweb.StateInfo:
    - you can use ctx.HttpServer().StateInfo() to get this object
    - you can visit /virtualPath/dotweb/state to list all state info
* 2019-06-26 08:00