### PR TITLE
Version 1.6.6 -  Add AccessLog middleware for logging HTTP requests in the Apache Common Log

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,7 +3,7 @@ package dotweb
 // Global define
 const (
 	// Version current version
-	Version = "1.6.5"
+	Version = "1.6.6"
 )
 
 // Log define

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -10,6 +10,8 @@ import (
 )
 
 const (
+	// LogLevelDebug raw log level
+	LogLevelRaw = "RAW"
 	// LogLevelDebug debug log level
 	LogLevelDebug = "DEBUG"
 	// LogLevelInfo info log level
@@ -25,8 +27,9 @@ type AppLog interface {
 	SetEnabledConsole(enabled bool)
 	SetEnabledLog(enabledLog bool)
 	IsEnabledLog() bool
-	Debug(log string, logTarget string)
 	Print(log string, logTarget string)
+	Raw(log string, logTarget string)
+	Debug(log string, logTarget string)
 	Info(log string, logTarget string)
 	Warn(log string, logTarget string)
 	Error(log string, logTarget string)

--- a/logger/xlog.go
+++ b/logger/xlog.go
@@ -40,14 +40,18 @@ const (
 	defaultTimeLayout            = "2006-01-02 15:04:05"
 )
 
-// Debug debug log with default format
-func (l *xLog) Debug(log string, logTarget string) {
-	l.log(log, logTarget, LogLevelDebug, false)
-}
-
 // Print debug log with no format
 func (l *xLog) Print(log string, logTarget string) {
 	l.log(log, logTarget, LogLevelDebug, true)
+}
+
+func (l *xLog) Raw(log string, logTarget string) {
+	l.log(log, logTarget, LogLevelRaw, true)
+}
+
+// Debug debug log with default format
+func (l *xLog) Debug(log string, logTarget string) {
+	l.log(log, logTarget, LogLevelDebug, false)
 }
 
 // Info info log with default format
@@ -74,8 +78,11 @@ func (l *xLog) log(log string, logTarget string, logLevel string, isRaw bool) {
 			fmt.Println("log println err! " + time.Now().Format("2006-01-02 15:04:05") + " Error: " + err.Error())
 			logCtx = &logContext{}
 		}
+		if logLevel != LogLevelRaw {
+			logTarget = logTarget + "_" + logLevel
+		}
 		chanLog := chanLog{
-			LogTarget: logTarget + "_" + logLevel,
+			LogTarget: logTarget,
 			Content:   log,
 			LogLevel:  logLevel,
 			isRaw:     isRaw,

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,19 @@
 ## dotweb版本记录：
 
+#### Version 1.6.6
+* New Feature: Add AccessLog middleware for logging HTTP requests in the Apache Common Log Format.
+* New Feature: Add Raw() in dotweb.Logger
+* About AccessLog:
+    - implement the Apache Common Log Format
+    - log file name like "dotweb_accesslog_2017_06_09.log"
+    - log-example: 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
+* How to use AccessLog middleware:
+~~~ go
+    app.Use(accesslog.Middleware())
+    server.GET("/", Index).Use(accesslog.Middleware())
+~~~
+* 2019-06-27 23:00 at 深圳华安大酒店
+
 #### Version 1.6.5
 * Architecture: move core.GlobalState to dotweb.StateInfo()
 * Architecture: add HttpServer.StateInfo() who is a shortcut for DotWeb.StateInfo()


### PR DESCRIPTION
* New Feature: Add AccessLog middleware for logging HTTP requests in the Apache Common Log Format.
* New Feature: Add Raw() in dotweb.Logger
* About AccessLog:
    - implement the Apache Common Log Format
    - log file name like "dotweb_accesslog_2017_06_09.log"
    - log-example: 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326
* How to use AccessLog middleware:
~~~ go
    app.Use(accesslog.Middleware())
    server.GET("/", Index).Use(accesslog.Middleware())
~~~
* 2019-06-27 23:00 at 深圳华安大酒店