### PR TITLE
add request max body size limit 

### DIFF
--- a/config/configs.go
+++ b/config/configs.go
@@ -52,6 +52,12 @@ type (
 		IndexPage                   string `xml:"indexpage,attr"`                // default index page
 		EnabledDetailRequestData    bool   `xml:"enableddetailrequestdata,attr"` // enable detailed statics for requests, default is false. Please use with care, it will have performance issues if the site have lots of URLs
 		VirtualPath                 string // virtual path when deploy on no root path
+		// To limit the request's body size to be read
+		// which can avoid unexpected or malicious request to cause the service's OOM
+		// default is 32 << 20 (32 mb)
+		// -1 : unlimted
+		// 0 : use default value
+		MaxBodySize int64
 	}
 
 	// SessionNode dotweb app's session config

--- a/context.go
+++ b/context.go
@@ -118,7 +118,6 @@ type (
 
 // reset response attr
 func (ctx *HttpContext) reset(res *Response, r *Request, server *HttpServer, node RouterNode, params Params, handler HttpHandle) {
-	r.httpCtx = ctx
 	ctx.request = r
 	ctx.response = res
 	ctx.routerNode = node

--- a/context.go
+++ b/context.go
@@ -118,6 +118,7 @@ type (
 
 // reset response attr
 func (ctx *HttpContext) reset(res *Response, r *Request, server *HttpServer, node RouterNode, params Params, handler HttpHandle) {
+	r.httpCtx = ctx
 	ctx.request = r
 	ctx.response = res
 	ctx.routerNode = node

--- a/context.go
+++ b/context.go
@@ -113,7 +113,6 @@ type (
 		items          core.ConcurrenceMap
 		viewData       core.ConcurrenceMap
 		handler        HttpHandle
-		maxBodySize    int64
 	}
 )
 

--- a/context.go
+++ b/context.go
@@ -113,6 +113,7 @@ type (
 		items          core.ConcurrenceMap
 		viewData       core.ConcurrenceMap
 		handler        HttpHandle
+		maxBodySize    int64
 	}
 )
 

--- a/dotweb_test.go
+++ b/dotweb_test.go
@@ -2,9 +2,10 @@ package dotweb
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/devfeel/dotweb/config"
 	"github.com/devfeel/dotweb/test"
-	"testing"
 )
 
 // 以下为功能测试
@@ -54,7 +55,7 @@ func TestDotWeb_UsePlugin(t *testing.T) {
 
 func newConfigDotWeb() *DotWeb {
 	app := New()
-	appConfig, err := config.InitConfig("d:/gotmp/dotweb.conf", "xml")
+	appConfig, err := config.InitConfig("config/testdata/dotweb.conf", "xml")
 	if err != nil {
 		fmt.Println("dotweb.InitConfig error => " + fmt.Sprint(err))
 		return nil

--- a/example/main.go
+++ b/example/main.go
@@ -30,6 +30,8 @@ func main() {
 	app.SetEnabledLog(true)
 
 	app.HttpServer.SetEnabledRequestID(true)
+	// 设置解析请求体大小为 10MB
+	app.HttpServer.SetMaxBodySize(10 << 20)
 
 	//开启development模式
 	app.SetDevelopmentMode()

--- a/request.go
+++ b/request.go
@@ -21,6 +21,7 @@ type Request struct {
 
 // reset response attr
 func (req *Request) reset(r *http.Request, ctx *HttpContext) {
+	req.httpCtx = ctx
 	req.Request = r
 	req.isReadBody = false
 	if ctx.HttpServer().ServerConfig().EnabledRequestID {

--- a/request.go
+++ b/request.go
@@ -135,15 +135,17 @@ func (req *Request) PostString(key string) string {
 // PostBody returns data from the POST or PUT request body
 func (req *Request) PostBody() []byte {
 	if !req.isReadBody {
-		switch req.httpCtx.maxBodySize {
-		case -1:
-			break
-		case 0:
-			req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, maxBodySize)
-			break
-		default:
-			req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, req.httpCtx.maxBodySize)
-			break
+		if req.httpCtx != nil {
+			switch req.httpCtx.maxBodySize {
+			case -1:
+				break
+			case 0:
+				req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, maxBodySize)
+				break
+			default:
+				req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, req.httpCtx.maxBodySize)
+				break
+			}
 		}
 		bts, err := ioutil.ReadAll(req.Body)
 		if err != nil {

--- a/request.go
+++ b/request.go
@@ -143,7 +143,7 @@ func (req *Request) PostBody() []byte {
 				req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, maxBodySize)
 				break
 			default:
-				req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, req.httpCtx.maxBodySize)
+				req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, req.httpCtx.httpServer.DotApp.Config.Server.MaxBodySize)
 				break
 			}
 		}

--- a/request.go
+++ b/request.go
@@ -136,7 +136,7 @@ func (req *Request) PostString(key string) string {
 func (req *Request) PostBody() []byte {
 	if !req.isReadBody {
 		if req.httpCtx != nil {
-			switch req.httpCtx.maxBodySize {
+			switch req.httpCtx.httpServer.DotApp.Config.Server.MaxBodySize {
 			case -1:
 				break
 			case 0:

--- a/router.go
+++ b/router.go
@@ -121,12 +121,6 @@ type (
 		// If enabled, the router automatically replies to OPTIONS requests.
 		// Custom OPTIONS handlers take priority over automatic replies.
 		HandleOPTIONS bool
-		// To limit the request's body size to be read
-		// which can avoid unexpected or malicious request to cause the service's OOM
-		// default is 32 << 20 (32 mb)
-		// -1 : unlimted
-		// 0 : use default value
-		MaxBodySize int64
 	}
 
 	// Handle is a function that can be registered to a route to handle HTTP
@@ -168,7 +162,6 @@ func NewRouter(server *HttpServer) *router {
 		server:                server,
 		handlerMap:            make(map[string]HttpHandle),
 		handlerMutex:          new(sync.RWMutex),
-		MaxBodySize:           0,
 	}
 }
 
@@ -215,7 +208,6 @@ func (r *router) ServeHTTP(ctx *HttpContext) {
 		if handle, ps, node, tsr := root.getValue(path); handle != nil {
 			ctx.routerParams = ps
 			ctx.routerNode = node
-			ctx.maxBodySize = r.MaxBodySize
 			handle(ctx)
 			return
 		} else if req.Method != "CONNECT" && path != "/" {

--- a/router.go
+++ b/router.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devfeel/dotweb/core"
 	"github.com/devfeel/dotweb/framework/convert"
 	"github.com/devfeel/dotweb/framework/exception"
-	_ "github.com/devfeel/dotweb/framework/file"
 	jsonutil "github.com/devfeel/dotweb/framework/json"
 	"golang.org/x/net/websocket"
 )

--- a/router.go
+++ b/router.go
@@ -14,7 +14,7 @@ import (
 	"github.com/devfeel/dotweb/framework/convert"
 	"github.com/devfeel/dotweb/framework/exception"
 	_ "github.com/devfeel/dotweb/framework/file"
-	"github.com/devfeel/dotweb/framework/json"
+	jsonutil "github.com/devfeel/dotweb/framework/json"
 	"golang.org/x/net/websocket"
 )
 
@@ -122,6 +122,12 @@ type (
 		// If enabled, the router automatically replies to OPTIONS requests.
 		// Custom OPTIONS handlers take priority over automatic replies.
 		HandleOPTIONS bool
+		// To limit the request's body size to be read
+		// which can avoid unexpected or malicious request to cause the service's OOM
+		// default is 32 << 20 (32 mb)
+		// -1 : unlimted
+		// 0 : use default value
+		MaxBodySize int64
 	}
 
 	// Handle is a function that can be registered to a route to handle HTTP
@@ -163,6 +169,7 @@ func NewRouter(server *HttpServer) *router {
 		server:                server,
 		handlerMap:            make(map[string]HttpHandle),
 		handlerMutex:          new(sync.RWMutex),
+		MaxBodySize:           0,
 	}
 }
 
@@ -209,6 +216,7 @@ func (r *router) ServeHTTP(ctx *HttpContext) {
 		if handle, ps, node, tsr := root.getValue(path); handle != nil {
 			ctx.routerParams = ps
 			ctx.routerNode = node
+			ctx.maxBodySize = r.MaxBodySize
 			handle(ctx)
 			return
 		} else if req.Method != "CONNECT" && path != "/" {

--- a/server.go
+++ b/server.go
@@ -82,7 +82,7 @@ func NewHttpServer() *HttpServer {
 // initConfig init config from app config
 func (server *HttpServer) initConfig() {
 	server.SetEnabledGzip(server.ServerConfig().EnabledGzip)
-
+	server.SetMaxBodySize(server.ServerConfig().MaxBodySize)
 	// VirtualPath config
 	if server.virtualPath == "" {
 		server.virtualPath = server.ServerConfig().VirtualPath

--- a/server.go
+++ b/server.go
@@ -2,12 +2,13 @@ package dotweb
 
 import (
 	"compress/gzip"
-	"github.com/devfeel/dotweb/logger"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
+
+	"github.com/devfeel/dotweb/logger"
 
 	"github.com/devfeel/dotweb/core"
 	"github.com/devfeel/dotweb/session"
@@ -16,7 +17,7 @@ import (
 
 	"github.com/devfeel/dotweb/config"
 	"github.com/devfeel/dotweb/framework/file"
-	"github.com/devfeel/dotweb/framework/json"
+	jsonutil "github.com/devfeel/dotweb/framework/json"
 )
 
 const (
@@ -447,6 +448,12 @@ func (server *HttpServer) SetEnabledDetailRequestData(isEnabled bool) {
 func (server *HttpServer) SetEnabledStaticFileMiddleware(isEnabled bool) {
 	server.ServerConfig().EnabledStaticFileMiddleware = isEnabled
 	server.Logger().Debug("DotWeb:HttpServer SetEnabledStaticFileMiddleware ["+strconv.FormatBool(isEnabled)+"]", LogTarget_HttpServer)
+}
+
+// SetMaxBodySize set body size to limit read
+func (server *HttpServer) SetMaxBodySize(maxBodySize int64) {
+	server.ServerConfig().MaxBodySize = maxBodySize
+	server.Logger().Debug("DotWeb:HttpServer SetMaxBodySize ["+strconv.FormatInt(maxBodySize, 10)+"]", LogTarget_HttpServer)
 }
 
 // RegisterModule add HttpModule


### PR DESCRIPTION
The situation that if we do not limit the request's body size,the func ioutil.ReadAll(req.Body) will caused OOM very soon if body size is very large.

To limit the request's body size to be read
which can avoid unexpected or malicious request to cause the service's OOM
- default is 32 << 20 (32 mb)
- -1 : unlimted
- 0 : use default value
- else: use other value

