### PR TITLE
HttpServer.RegisterServerFile增加excludeExtension参数

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrValidatorNotRegistered error for not register Validator
 var ErrValidatorNotRegistered = errors.New("validator not registered")
+
+// ErrNotFound error for not found file
+var ErrNotFound = errors.New("not found file")

--- a/server.go
+++ b/server.go
@@ -321,9 +321,10 @@ func (server *HttpServer) ServerFile(path string, fileRoot string) RouterNode {
 }
 
 // RegisterServerFile a shortcut for router.RegisterServerFile(routeMethod, path, fileRoot)
-// simple demo:server.RegisterServerFile(RouteMethod_GET, "/src/*filepath", "/var/www")
-func (server *HttpServer) RegisterServerFile(routeMethod string, path string, fileRoot string) RouterNode {
-	return server.Router().RegisterServerFile(routeMethod, path, fileRoot)
+// simple demo:server.RegisterServerFile(RouteMethod_GET, "/src/*", "/var/www", nil)
+// simple demo:server.RegisterServerFile(RouteMethod_GET, "/src/*filepath", "/var/www", []string{".zip", ".rar"})
+func (server *HttpServer) RegisterServerFile(routeMethod string, path string, fileRoot string, excludeExtension []string) RouterNode {
+	return server.Router().RegisterServerFile(routeMethod, path, fileRoot, excludeExtension)
 }
 
 // HiJack is a shortcut for router.HiJack(path, handle)

--- a/version.MD
+++ b/version.MD
@@ -1,6 +1,17 @@
 ## dotweb版本记录：
 
 
+#### Version 1.7.4
+* New Feature: HttpServer.RegisterServerFile增加excludeExtension参数，用于设置不希望被访问的文件后缀名
+* Update: 增加ErrNotFound
+* About HttpServer.RegisterServerFile:
+    - Demo: server.RegisterServerFile(RouteMethod_GET, "/src/*", "/var/www", nil)
+    - Demo: server.RegisterServerFile(RouteMethod_GET, "/src/*filepath", "/var/www", []string{".zip", ".rar"})
+    - 当设置excludeExtension为nil时，可访问所有文件
+    - 本次更新涉及API变更
+* Fixed for issue #125 & #212
+* 2019-11-04 01:00 at ShangHai
+
 #### Version 1.7.3
 * New Feature: Request.PostBody增加Post内容大小限制,默认为32mb
 * About MaxBodySize:


### PR DESCRIPTION
#### Version 1.7.4
* New Feature: HttpServer.RegisterServerFile增加excludeExtension参数，用于设置不希望被访问的文件后缀名
* Update: 增加ErrNotFound
* About HttpServer.RegisterServerFile:
    - Demo: server.RegisterServerFile(RouteMethod_GET, "/src/*", "/var/www", nil)
    - Demo: server.RegisterServerFile(RouteMethod_GET, "/src/*filepath", "/var/www", []string{".zip", ".rar"})
    - 当设置excludeExtension为nil时，可访问所有文件
    - 本次更新涉及API变更
* Fixed for issue #125 & #212
* 2019-11-04 01:00 at ShangHai