### PR TITLE
新增支持注册go原生http.HandlerFunc形式的函数

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -3,7 +3,7 @@ package dotweb
 // Global define
 const (
 	// Version current version
-	Version = "1.7.1"
+	Version = "1.7.5"
 )
 
 // Log define

--- a/example/router/main.go
+++ b/example/router/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/devfeel/dotweb"
@@ -41,8 +42,13 @@ func Any(ctx dotweb.Context) error {
 	return ctx.WriteString("any - " + ctx.Request().Method)
 }
 
+func HandlerFunc(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("go raw http func"))
+}
+
 func InitRoute(server *dotweb.HttpServer) {
 	server.GET("/", Index)
 	server.GET("/d/:x/y", Index)
 	server.Any("/any", Any)
+	server.RegisterHandlerFunc("GET", "/h/func", HandlerFunc)
 }

--- a/server.go
+++ b/server.go
@@ -320,6 +320,16 @@ func (server *HttpServer) ServerFile(path string, fileRoot string) RouterNode {
 	return server.Router().ServerFile(path, fileRoot)
 }
 
+// RegisterHandlerFunc a shortcut for router.RegisterHandlerFunc(routeMethod string, path string, handler http.HandlerFunc)
+func (server *HttpServer) RegisterHandlerFunc(routeMethod string, path string, handler http.HandlerFunc) RouterNode {
+	return server.Router().RegisterHandlerFunc(routeMethod, path, handler)
+}
+
+// RegisterRoute a shortcut for router.RegisterRoute(routeMethod string, path string,handle HttpHandle)
+func (server *HttpServer) RegisterRoute(routeMethod string, path string, handle HttpHandle) RouterNode {
+	return server.Router().RegisterRoute(routeMethod, path, handle)
+}
+
 // RegisterServerFile a shortcut for router.RegisterServerFile(routeMethod, path, fileRoot)
 // simple demo:server.RegisterServerFile(RouteMethod_GET, "/src/*", "/var/www", nil)
 // simple demo:server.RegisterServerFile(RouteMethod_GET, "/src/*filepath", "/var/www", []string{".zip", ".rar"})

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,21 @@
 ## dotweb版本记录：
 
+#### Version 1.7.5
+* Feature: Router增加RegisterHandlerFunc,用于支持注册go原生http.HandlerFunc形式的函数
+* Feature: HttpServer增加RegisterHandlerFunc与RegisterRoute
+* Opt: Router增加transferHandlerFunc、transferStaticFileHandler辅助函数
+* Example: 修改example/router增加RegisterHandlerFunc示例
+* About RegisterHandlerFunc
+    - Func: RegisterHandlerFunc(routeMethod string, path string, handler http.HandlerFunc) RouterNode
+* How to use RegisterHandlerFunc:
+~~~ go
+func HandlerFunc(w http.ResponseWriter, r *http.Request){
+	w.Write([]byte("go raw http func"))
+}
+
+server.RegisterHandlerFunc("GET", "/h/func", HandlerFunc)
+~~~
+* 2019-11-07 01:00 at ShangHai
 
 #### Version 1.7.4
 * New Feature: HttpServer.RegisterServerFile增加excludeExtension参数，用于设置不希望被访问的文件后缀名


### PR DESCRIPTION
#### Version 1.7.5
* Feature: Router增加RegisterHandlerFunc,用于支持注册go原生http.HandlerFunc形式的函数
* Feature: HttpServer增加RegisterHandlerFunc与RegisterRoute
* Opt: Router增加transferHandlerFunc、transferStaticFileHandler辅助函数
* Example: 修改example/router增加RegisterHandlerFunc示例
* About RegisterHandlerFunc
    - Func: RegisterHandlerFunc(routeMethod string, path string, handler http.HandlerFunc) RouterNode
* How to use RegisterHandlerFunc:
~~~ go
func HandlerFunc(w http.ResponseWriter, r *http.Request){
	w.Write([]byte("go raw http func"))
}

server.RegisterHandlerFunc("GET", "/h/func", HandlerFunc)
~~~
* 2019-11-07 01:00 at ShangHai