### PR TITLE
Version 1.7.14 fixed can not set redis maxIdle & maxActive when use redis session, fix for issue #236

### DIFF
--- a/cache/redis/cache_redis.go
+++ b/cache/redis/cache_redis.go
@@ -24,14 +24,14 @@ func NewRedisCache(serverURL string) *RedisCache {
 
 // Exists check item exist in redis cache.
 func (ca *RedisCache) Exists(key string) (bool, error) {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	exists, err := redisClient.Exists(key)
 	return exists, err
 }
 
 // Incr increase int64 counter in redis cache.
 func (ca *RedisCache) Incr(key string) (int64, error) {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	val, err := redisClient.INCR(key)
 	if err != nil {
 		return 0, err
@@ -41,7 +41,7 @@ func (ca *RedisCache) Incr(key string) (int64, error) {
 
 // Decr decrease counter in redis cache.
 func (ca *RedisCache) Decr(key string) (int64, error) {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	val, err := redisClient.DECR(key)
 	if err != nil {
 		return 0, err
@@ -52,7 +52,7 @@ func (ca *RedisCache) Decr(key string) (int64, error) {
 // Get cache from redis cache.
 // if non-existed or expired, return nil.
 func (ca *RedisCache) Get(key string) (interface{}, error) {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	reply, err := redisClient.GetObj(key)
 	return reply, err
 }
@@ -60,7 +60,7 @@ func (ca *RedisCache) Get(key string) (interface{}, error) {
 //  returns value string format by given key
 // if non-existed or expired, return "".
 func (ca *RedisCache) GetString(key string) (string, error) {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	reply, err := redisClient.Get(key)
 	return reply, err
 }
@@ -100,7 +100,7 @@ func (ca *RedisCache) GetInt64(key string) (int64, error) {
 // Set cache to redis.
 // ttl is second, if ttl is 0, it will be forever.
 func (ca *RedisCache) Set(key string, value interface{}, ttl int64) error {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	var err error
 	if ttl <= 0 {
 		_, err = redisClient.Set(key, value)
@@ -113,7 +113,7 @@ func (ca *RedisCache) Set(key string, value interface{}, ttl int64) error {
 // Delete item in redis cacha.
 // if not exists, we think it's success
 func (ca *RedisCache) Delete(key string) error {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	_, err := redisClient.Del(key)
 	return err
 }
@@ -121,7 +121,7 @@ func (ca *RedisCache) Delete(key string) error {
 // ClearAll will delete all item in redis cache.
 // never error
 func (ca *RedisCache) ClearAll() error {
-	redisClient := redisutil.GetRedisClient(ca.serverURL)
+	redisClient := redisutil.GetDefaultRedisClient(ca.serverURL)
 	redisClient.FlushDB()
 	return nil
 }

--- a/config/configs.go
+++ b/config/configs.go
@@ -69,6 +69,8 @@ type (
 		ServerIP        string `xml:"serverip,attr"`        // remote session server url
 		BackupServerUrl string `xml:"backupserverurl,attr"` // backup remote session server url
 		StoreKeyPre     string `xml:"storekeypre,attr"`     // remote session StoreKeyPre
+		MaxIdle         int    `xml:"maxidle,attr"`         // remote session MaxIdle
+		MaxActive       int    `xml:"maxactive,attr"`       // remote session MaxActive
 	}
 
 	// RouterNode dotweb app's router config

--- a/dotweb.go
+++ b/dotweb.go
@@ -670,7 +670,7 @@ func (app *DotWeb) printDotLogo() {
 	app.Logger().Print(`  / / / / / __ \ / __/| | /| / / / _ \  / __ \`, LogTarget_HttpServer)
 	app.Logger().Print(` / /_/ / / /_/ // /_  | |/ |/ / /  __/ / /_/ /`, LogTarget_HttpServer)
 	app.Logger().Print(`/_____/  \____/ \__/  |__/|__/  \___/ /_.___/`, LogTarget_HttpServer)
-	app.Logger().Print(`                                  Happy 6.1`, LogTarget_HttpServer)
+	app.Logger().Print(`                             Version 1.7.14`, LogTarget_HttpServer)
 }
 
 // Close immediately stops the server.

--- a/server.go
+++ b/server.go
@@ -218,6 +218,8 @@ func (server *HttpServer) SetSessionConfig(storeConfig *session.StoreConfig) {
 	server.SessionConfig().BackupServerUrl = storeConfig.BackupServerUrl
 	server.SessionConfig().StoreKeyPre = storeConfig.StoreKeyPre
 	server.SessionConfig().CookieName = storeConfig.CookieName
+	server.SessionConfig().MaxIdle = storeConfig.MaxIdle
+	server.SessionConfig().MaxActive = storeConfig.MaxActive
 	server.DotApp.Logger().Debug("DotWeb:HttpServer SetSessionConfig ["+jsonutil.GetJsonString(storeConfig)+"]", LogTarget_HttpServer)
 }
 
@@ -229,6 +231,8 @@ func (server *HttpServer) InitSessionManager() {
 	storeConfig.ServerIP = server.SessionConfig().ServerIP
 	storeConfig.BackupServerUrl = server.SessionConfig().BackupServerUrl
 	storeConfig.StoreKeyPre = server.SessionConfig().StoreKeyPre
+	storeConfig.MaxIdle = server.SessionConfig().MaxIdle
+	storeConfig.MaxActive = server.SessionConfig().MaxActive
 	storeConfig.CookieName = server.SessionConfig().CookieName
 
 	if server.sessionManager == nil {

--- a/session/session.go
+++ b/session/session.go
@@ -40,6 +40,8 @@ type (
 		ServerIP        string // if use redis, connection string, like "redis://:password@10.0.1.11:6379/0"
 		BackupServerUrl string // if use redis, if ServerIP is down, use this server, like "redis://:password@10.0.1.11:6379/0"
 		StoreKeyPre     string // if use redis, set custom redis key-pre; default is dotweb:session:
+		MaxIdle         int    // if use redis, set MaxIdle; default is 10
+		MaxActive       int    // if use redis, set MaxActive; default is 50
 	}
 
 	SessionManager struct {
@@ -71,27 +73,29 @@ func GetSessionStore(config *StoreConfig) SessionStore {
 
 // NewDefaultRuntimeConfig create new store with default config and use runtime store
 func NewDefaultRuntimeConfig() *StoreConfig {
-	return NewStoreConfig(SessionMode_Runtime, DefaultSessionMaxLifeTime, "", "")
+	return NewStoreConfig(SessionMode_Runtime, DefaultSessionMaxLifeTime, "", "", 0, 0)
 }
 
 // NewDefaultRedisConfig create new store with default config and use redis store
 func NewDefaultRedisConfig(serverIp string) *StoreConfig {
-	return NewStoreConfig(SessionMode_Redis, DefaultSessionMaxLifeTime, serverIp, "")
+	return NewRedisConfig(serverIp, DefaultSessionMaxLifeTime, "", 0, 0)
 }
 
 // NewRedisConfig create new store with config and use redis store
 // must set serverIp and storeKeyPre
-func NewRedisConfig(serverIp string, storeKeyPre string) *StoreConfig {
-	return NewStoreConfig(SessionMode_Redis, DefaultSessionMaxLifeTime, serverIp, storeKeyPre)
+func NewRedisConfig(serverIp string, maxlifetime int64, storeKeyPre string, maxIdle int, maxActive int) *StoreConfig {
+	return NewStoreConfig(SessionMode_Redis, maxlifetime, serverIp, storeKeyPre, maxIdle, maxActive)
 }
 
 // NewStoreConfig create new store config
-func NewStoreConfig(storeName string, maxlifetime int64, serverIp string, storeKeyPre string) *StoreConfig {
+func NewStoreConfig(storeName string, maxlifetime int64, serverIp string, storeKeyPre string, maxIdle int, maxActive int) *StoreConfig {
 	return &StoreConfig{
 		StoreName:   storeName,
 		Maxlifetime: maxlifetime,
 		ServerIP:    serverIp,
 		StoreKeyPre: storeKeyPre,
+		MaxIdle:     maxIdle,
+		MaxActive:   maxActive,
 	}
 }
 

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,20 @@
 ## dotweb版本记录：
 
+#### Version 1.7.14
+* fix: fixed can not set redis maxIdle & maxActive when use redis session, fix for issue #236
+* refactor: add StoreConfig.MaxIdle & StoreConfig.MaxActive set redis maxIdle & maxActive
+* refactor: add redisutil.GetDefaultRedisClient to returns the RedisClient of specified address
+* refactor: update redisutil.GetRedisClient returns the RedisClient of specified address & maxIdle & maxActive
+* opt: set defaultMaxIdle=10, defaultMaxActive=50 when use default redis config
+* How to set redis maxIdle & maxActive when use redis session:
+~~~ go
+sessionConf := session.NewDefaultRedisConfig("redis://xx.xx.xx.xx:6379/0")
+sessionConf.BackupServerUrl = "redis://xx.xx.xx.xx:6379/0"
+sessionConf.CookieName = "dotweb-example.SessionID"
+sessionConf.MaxIdle = 20
+sessionConf.MaxActive = 100
+~~~
+* 2020-12-19 21:00 at ShangHai
 
 #### Version 1.7.13
 * fix: fixed can not get correct Path which in Post requests


### PR DESCRIPTION
* fix: fixed can not set redis maxIdle & maxActive when use redis session, fix for issue #236
* refactor: add StoreConfig.MaxIdle & StoreConfig.MaxActive set redis maxIdle & maxActive
* refactor: add redisutil.GetDefaultRedisClient to returns the RedisClient of specified address
* refactor: update redisutil.GetRedisClient returns the RedisClient of specified address & maxIdle & maxActive
* opt: set defaultMaxIdle=10, defaultMaxActive=50 when use default redis config
* How to set redis maxIdle & maxActive when use redis session:
~~~ go
sessionConf := session.NewDefaultRedisConfig("redis://xx.xx.xx.xx:6379/0")
sessionConf.BackupServerUrl = "redis://xx.xx.xx.xx:6379/0"
sessionConf.CookieName = "dotweb-example.SessionID"
sessionConf.MaxIdle = 20
sessionConf.MaxActive = 100
~~~
* 2020-12-19 21:00 at ShangHai