### PR TITLE
Version 1.7.16: replace *HttpContext to Context interface & fix middleware chain misbehaving in netsed groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ go get github.com/devfeel/dotweb
 ```
 
 ## 2. Getting Started
-```go
+``` go
 package main
 
 import (
@@ -58,6 +58,7 @@ func main() {
 * Feature支持，可绑定HttpServer全局启用
 * 支持STRING/JSON/JSONP/HTML格式输出
 * 集成Mock能力
+* 支持自定义Context
 * 集成Timeout Hook
 * 全局HTTP错误处理
 * 全局日志处理
@@ -103,26 +104,26 @@ cpu | 内存 | Samples | Average | Median | 90%Line | 95%Line | 99%Line | Min | 
 * 支持通过配置开启默认添加HEAD方式
 * 支持注册Handler，以启用配置化
 * 支持检查请求与指定路由是否匹配
-```go
-1、Router.GET(path string, handle HttpHandle)
-2、Router.POST(path string, handle HttpHandle)
-3、Router.HEAD(path string, handle HttpHandle)
-4、Router.OPTIONS(path string, handle HttpHandle)
-5、Router.PUT(path string, handle HttpHandle)
-6、Router.PATCH(path string, handle HttpHandle)
-7、Router.DELETE(path string, handle HttpHandle)
-8、Router.HiJack(path string, handle HttpHandle)
-9、Router.WebSocket(path string, handle HttpHandle)
-10、Router.Any(path string, handle HttpHandle)
-11、Router.RegisterRoute(routeMethod string, path string, handle HttpHandle)
-12、Router.RegisterHandler(name string, handler HttpHandle)
-13、Router.GetHandler(name string) (HttpHandle, bool)
-14、Router.MatchPath(ctx Context, routePath string) bool
+``` go
+Router.GET(path string, handle HttpHandle)
+Router.POST(path string, handle HttpHandle)
+Router.HEAD(path string, handle HttpHandle)
+Router.OPTIONS(path string, handle HttpHandle)
+Router.PUT(path string, handle HttpHandle)
+Router.PATCH(path string, handle HttpHandle)
+Router.DELETE(path string, handle HttpHandle)
+Router.HiJack(path string, handle HttpHandle)
+Router.WebSocket(path string, handle HttpHandle)
+Router.Any(path string, handle HttpHandle)
+Router.RegisterRoute(routeMethod string, path string, handle HttpHandle)
+Router.RegisterHandler(name string, handler HttpHandle)
+Router.GetHandler(name string) (HttpHandle, bool)
+Router.MatchPath(ctx Context, routePath string) bool
 ```
 接受两个参数，一个是URI路径，另一个是 HttpHandle 类型，设定匹配到该路径时执行的方法；
 #### 2) static router
 静态路由语法就是没有任何参数变量，pattern是一个固定的字符串。
-```go
+``` go
 package main
 
 import (
@@ -141,7 +142,7 @@ test：
 curl http://127.0.0.1/hello
 #### 3) parameter router
 参数路由以冒号 : 后面跟一个字符串作为参数名称，可以通过 HttpContext的 GetRouterName 方法获取路由参数的值。
-```go
+``` go
 package main
 
 import (
@@ -165,7 +166,7 @@ test：
 <br>curl http://127.0.0.1/hello/devfeel
 <br>curl http://127.0.0.1/hello/category1/1
 #### 4) group router
-```go
+``` go
     g := server.Group("/user")
 	g.GET("/", Index)
 	g.GET("/profile", Profile)
@@ -178,7 +179,7 @@ test：
 ## 6. Binder
 * HttpContext.Bind(interface{})
 * Support data from json、xml、Form
-```go
+``` go
 type UserInfo struct {
 		UserName string `form:"user"`
 		Sex      int    `form:"sex"`
@@ -213,7 +214,7 @@ func TestBind(ctx dotweb.HttpContext) error{
 * Recover
 * HeaderOverride
 
-```go
+``` go
 app.Use(NewAccessFmtLog("app"))
 
 func InitRoute(server *dotweb.HttpServer) {
@@ -286,13 +287,13 @@ func NewAccessFmtLog(index string) *AccessFmtLog {
 #### 500 error
 * Default: 当发生未处理异常时，会根据RunMode向页面输出默认错误信息或者具体异常信息，并返回 500 错误头
 * User-defined: 通过DotServer.SetExceptionHandle(handler *ExceptionHandle)实现自定义异常处理逻辑
-```go
+``` go
 type ExceptionHandle func(Context, error)
 ```
 #### 404 error
 * Default: 当发生404异常时，会默认使用http.NotFound处理
 * User-defined: 通过DotWeb.SetNotFoundHandle(handler NotFoundHandle)实现自定义404处理逻辑
-```go
+``` go
 type NotFoundHandle  func(http.ResponseWriter, *http.Request)
 ```
 

--- a/context.go
+++ b/context.go
@@ -144,8 +144,8 @@ type (
 	}
 )
 
-// DefaultContext return new HttpContex{}
-func DefaultContext() Context {
+// defaultContextCreater return new HttpContex{}
+func defaultContextCreater() Context {
 	return &HttpContext{}
 }
 

--- a/context.go
+++ b/context.go
@@ -95,6 +95,13 @@ type (
 		WriteJsonBlobC(code int, b []byte) error
 		WriteJsonp(callback string, i interface{}) error
 		WriteJsonpBlob(callback string, b []byte) error
+
+		//inner func
+		getMiddlewareStep() string
+		setMiddlewareStep(step string)
+		release()
+		reset(res *Response, r *Request, server *HttpServer, node RouterNode, params Params, handler HttpHandle)
+		setSessionID(id string)
 	}
 
 	HttpContext struct {
@@ -131,6 +138,8 @@ type (
 		header     string
 	}
 )
+
+//************* HttpContext public func **********************
 
 // reset response attr
 func (ctx *HttpContext) reset(res *Response, r *Request, server *HttpServer, node RouterNode, params Params, handler HttpHandle) {
@@ -639,6 +648,25 @@ func (ctx *HttpContext) WriteJsonpBlob(callback string, b []byte) error {
 	return err
 }
 
+//**************** HttpContext inner func ************************
+
+// setMiddlewareStep
+func (ctx *HttpContext) setMiddlewareStep(step string) {
+	ctx.middlewareStep = step
+}
+
+// getMiddlewareStep
+func (ctx *HttpContext) getMiddlewareStep() string {
+	return ctx.middlewareStep
+}
+
+// setSessionID
+func (ctx *HttpContext) setSessionID(id string) {
+	ctx.sessionID = id
+}
+
+//************* WebSocket public func **********************
+
 // Request get http request
 func (ws *WebSocket) Request() *http.Request {
 	return ws.Conn.Request()
@@ -655,6 +683,8 @@ func (ws *WebSocket) ReadMessage() (string, error) {
 	err := websocket.Message.Receive(ws.Conn, &str)
 	return str, err
 }
+
+//************* HijackConn public func **********************
 
 // WriteString hjiack conn write string
 func (hj *HijackConn) WriteString(content string) (int, error) {

--- a/context.go
+++ b/context.go
@@ -139,6 +139,11 @@ type (
 	}
 )
 
+// DefaultContext return new HttpContex{}
+func DefaultContext() Context {
+	return &HttpContext{}
+}
+
 //************* HttpContext public func **********************
 
 // reset response attr

--- a/context.go
+++ b/context.go
@@ -102,12 +102,17 @@ type (
 		release()
 		reset(res *Response, r *Request, server *HttpServer, node RouterNode, params Params, handler HttpHandle)
 		setSessionID(id string)
+		setRouterParams(params Params)
+		setRouterNode(node RouterNode)
+		setHandler(handler HttpHandle)
+		getCancel() context.CancelFunc
+		setCancel(cancel context.CancelFunc)
 	}
 
 	HttpContext struct {
 		context context.Context
 		// Reserved
-		cancle         context.CancelFunc
+		cancel         context.CancelFunc
 		middlewareStep string
 		request        *Request
 		routerNode     RouterNode
@@ -193,7 +198,7 @@ func (ctx *HttpContext) Context() context.Context {
 // set Context & cancle
 // withvalue RequestID
 func (ctx *HttpContext) SetTimeoutContext(timeout time.Duration) context.Context {
-	ctx.context, ctx.cancle = context.WithTimeout(context.Background(), timeout)
+	ctx.context, ctx.cancel = context.WithTimeout(context.Background(), timeout)
 	ctx.context = context.WithValue(ctx.context, "RequestID", ctx.Request().RequestID())
 	return ctx.context
 }
@@ -668,6 +673,31 @@ func (ctx *HttpContext) getMiddlewareStep() string {
 // setSessionID
 func (ctx *HttpContext) setSessionID(id string) {
 	ctx.sessionID = id
+}
+
+// setRouterParams
+func (ctx *HttpContext) setRouterParams(params Params) {
+	ctx.routerParams = params
+}
+
+// setRouterNode
+func (ctx *HttpContext) setRouterNode(node RouterNode) {
+	ctx.routerNode = node
+}
+
+// setHandler
+func (ctx *HttpContext) setHandler(handler HttpHandle) {
+	ctx.handler = handler
+}
+
+// getCancel return context.CancelFunc
+func (ctx *HttpContext) getCancel() context.CancelFunc {
+	return ctx.cancel
+}
+
+// setCancel
+func (ctx *HttpContext) setCancel(cancel context.CancelFunc) {
+	ctx.cancel = cancel
 }
 
 //************* WebSocket public func **********************

--- a/example/main.go
+++ b/example/main.go
@@ -37,6 +37,9 @@ func main() {
 	app.SetDevelopmentMode()
 	app.SetProductionMode()
 
+	//设置自定义Context
+	app.HttpServer.SetContextCreater(testContextCreater)
+
 	//设置gzip开关
 	//app.HttpServer.SetEnabledGzip(true)
 
@@ -99,7 +102,7 @@ func main() {
 
 func Index(ctx dotweb.Context) error {
 	ctx.Response().Header().Set("Content-Type", "text/html; charset=utf-8")
-	ctx.Write(200, []byte(ctx.Request().RemoteIP()))
+	ctx.Write(200, []byte(ctx.Request().RemoteIP()+" "+ctx.(*testContext).TestInfo))
 	//_, err := ctx.WriteStringC(201, "index => ", ctx.RemoteIP(), "我是首页")
 	return nil
 }
@@ -116,6 +119,10 @@ func Time(ctx dotweb.Context) error {
 		//ctx.WriteString(t.Sub(time.Now()) > 5*time.Minute)
 	}
 	return nil
+}
+
+func OutputTestInfo(ctx dotweb.Context) error {
+	return ctx.WriteString(ctx.(*testContext).TestInfo)
 }
 
 func IndexReg(ctx dotweb.Context) error {
@@ -188,4 +195,13 @@ func InitRoute(server *dotweb.HttpServer) {
 	server.POST("/readpost", ReadPost)
 	server.GET("/pretty", IndexPretty)
 	//server.Router().RegisterRoute(dotweb.RouteMethod_GET, "/index", IndexReg)
+}
+
+type testContext struct {
+	dotweb.HttpContext
+	TestInfo string
+}
+
+func testContextCreater() dotweb.Context {
+	return &testContext{TestInfo: "Test"}
 }

--- a/example/middleware/main.go
+++ b/example/middleware/main.go
@@ -52,6 +52,11 @@ func Index(ctx dotweb.Context) error {
 	return err
 }
 
+func ShowMiddlewares(ctx dotweb.Context) error {
+	err := ctx.WriteString("ShowMiddlewares  => ", ctx.RouterNode().GroupMiddlewares())
+	return err
+}
+
 func InitRoute(server *dotweb.HttpServer) {
 	server.Router().GET("/", Index)
 	server.Router().GET("/index", Index)
@@ -59,9 +64,20 @@ func InitRoute(server *dotweb.HttpServer) {
 	server.Router().GET("/v1/machines/queryIP2", Index)
 	server.Router().GET("/use", Index).Use(NewAccessFmtLog("Router-use"))
 
-	g := server.Group("/group").Use(NewAccessFmtLog("group")).Use(NewSimpleAuth("admin"))
+	/*g := server.Group("/group").Use(NewAccessFmtLog("group")).Use(NewSimpleAuth("admin"))
 	g.GET("/", Index)
-	g.GET("/use", Index).Use(NewAccessFmtLog("group-use"))
+	g.GET("/use", Index).Use(NewAccessFmtLog("group-use"))*/
+
+	g := server.Group("/A").Use(NewAGroup())
+	g.GET("/", ShowMiddlewares)
+	g1 := g.Group("/B").Use(NewBGroup())
+	g1.GET("/", ShowMiddlewares)
+	g2 := g.Group("/C").Use(NewCGroup())
+	g2.GET("/", ShowMiddlewares)
+
+	g = server.Group("/B").Use(NewBGroup())
+	g.GET("/", ShowMiddlewares)
+
 }
 
 func InitModule(dotserver *dotweb.HttpServer) {
@@ -121,4 +137,46 @@ func (m *SimpleAuth) Handle(ctx dotweb.Context) error {
 
 func NewSimpleAuth(exactToken string) *SimpleAuth {
 	return &SimpleAuth{exactToken: exactToken}
+}
+
+type AGroup struct {
+	dotweb.BaseMiddleware
+}
+
+func (m *AGroup) Handle(ctx dotweb.Context) error {
+	fmt.Println(time.Now(), "[AGroup] request)")
+	err := m.Next(ctx)
+	return err
+}
+
+func NewAGroup() *AGroup {
+	return &AGroup{}
+}
+
+type BGroup struct {
+	dotweb.BaseMiddleware
+}
+
+func (m *BGroup) Handle(ctx dotweb.Context) error {
+	fmt.Println(time.Now(), "[BGroup] request)")
+	err := m.Next(ctx)
+	return err
+}
+
+func NewBGroup() *BGroup {
+	return &BGroup{}
+}
+
+type CGroup struct {
+	dotweb.BaseMiddleware
+}
+
+func (m *CGroup) Handle(ctx dotweb.Context) error {
+	fmt.Println(time.Now(), "[CGroup] request)")
+	err := m.Next(ctx)
+	return err
+}
+
+func NewCGroup() *CGroup {
+	return &CGroup{}
 }

--- a/middleware.go
+++ b/middleware.go
@@ -60,26 +60,25 @@ func (bm *BaseMiddleware) SetNext(m Middleware) {
 }
 
 func (bm *BaseMiddleware) Next(ctx Context) error {
-	httpCtx := ctx.(*HttpContext)
-	if httpCtx.middlewareStep == "" {
-		httpCtx.middlewareStep = middleware_App
+	if ctx.getMiddlewareStep() == "" {
+		ctx.setMiddlewareStep(middleware_App)
 	}
 	if bm.next == nil {
-		if httpCtx.middlewareStep == middleware_App {
-			httpCtx.middlewareStep = middleware_Group
-			if len(httpCtx.RouterNode().GroupMiddlewares()) > 0 {
-				return httpCtx.RouterNode().GroupMiddlewares()[0].Handle(ctx)
+		if ctx.getMiddlewareStep() == middleware_App {
+			ctx.setMiddlewareStep(middleware_Group)
+			if len(ctx.RouterNode().GroupMiddlewares()) > 0 {
+				return ctx.RouterNode().GroupMiddlewares()[0].Handle(ctx)
 			}
 		}
-		if httpCtx.middlewareStep == middleware_Group {
-			httpCtx.middlewareStep = middleware_Router
-			if len(httpCtx.RouterNode().Middlewares()) > 0 {
-				return httpCtx.RouterNode().Middlewares()[0].Handle(ctx)
+		if ctx.getMiddlewareStep() == middleware_Group {
+			ctx.setMiddlewareStep(middleware_Router)
+			if len(ctx.RouterNode().Middlewares()) > 0 {
+				return ctx.RouterNode().Middlewares()[0].Handle(ctx)
 			}
 		}
 
-		if httpCtx.middlewareStep == middleware_Router {
-			return httpCtx.Handler()(ctx)
+		if ctx.getMiddlewareStep() == middleware_Router {
+			return ctx.Handler()(ctx)
 		}
 	} else {
 		// check exclude config
@@ -136,12 +135,11 @@ func getIgnoreFaviconModule() *HttpModule {
 }
 
 func (x *xMiddleware) Handle(ctx Context) error {
-	httpCtx := ctx.(*HttpContext)
-	if httpCtx.middlewareStep == "" {
-		httpCtx.middlewareStep = middleware_App
+	if ctx.getMiddlewareStep() == "" {
+		ctx.setMiddlewareStep(middleware_App)
 	}
 	if x.IsEnd {
-		return httpCtx.Handler()(ctx)
+		return ctx.Handler()(ctx)
 	}
 	return x.Next(ctx)
 }

--- a/request.go
+++ b/request.go
@@ -12,7 +12,7 @@ var maxBodySize int64 = 32 << 20 // 32 MB
 
 type Request struct {
 	*http.Request
-	httpCtx    *HttpContext
+	httpCtx    Context
 	postBody   []byte
 	realUrl    string
 	isReadBody bool
@@ -20,13 +20,13 @@ type Request struct {
 }
 
 // reset response attr
-func (req *Request) reset(r *http.Request, ctx *HttpContext) {
+func (req *Request) reset(r *http.Request, ctx Context) {
 	req.httpCtx = ctx
 	req.Request = r
 	req.isReadBody = false
 	if ctx.HttpServer().ServerConfig().EnabledRequestID {
 		req.requestID = ctx.HttpServer().DotApp.IDGenerater()
-		ctx.response.SetHeader(HeaderRequestID, req.requestID)
+		ctx.Response().SetHeader(HeaderRequestID, req.requestID)
 	} else {
 		req.requestID = ""
 	}
@@ -151,14 +151,14 @@ func (req *Request) PostString(key string) string {
 func (req *Request) PostBody() []byte {
 	if !req.isReadBody {
 		if req.httpCtx != nil {
-			switch req.httpCtx.httpServer.DotApp.Config.Server.MaxBodySize {
+			switch req.httpCtx.HttpServer().DotApp.Config.Server.MaxBodySize {
 			case -1:
 				break
 			case 0:
-				req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, maxBodySize)
+				req.Body = http.MaxBytesReader(req.httpCtx.Response().Writer(), req.Body, maxBodySize)
 				break
 			default:
-				req.Body = http.MaxBytesReader(req.httpCtx.response.Writer(), req.Body, req.httpApp().Config.Server.MaxBodySize)
+				req.Body = http.MaxBytesReader(req.httpCtx.Response().Writer(), req.Body, req.httpApp().Config.Server.MaxBodySize)
 				break
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -64,7 +64,7 @@ func NewHttpServer() *HttpServer {
 			},
 			context: sync.Pool{
 				New: func() interface{} {
-					return &HttpContext{}
+					return DefaultContext()
 				},
 			},
 		},

--- a/tree.go
+++ b/tree.go
@@ -150,15 +150,17 @@ func (n *Node) addRoute(path string, handle RouterHandle, m ...Middleware) (outn
 			// Split edge
 			if i < len(n.path) {
 				child := Node{
-					path:        n.path[i:],
-					fullPath:    n.fullPath,
-					wildChild:   n.wildChild,
-					nType:       static,
-					indices:     n.indices,
-					children:    n.children,
-					handle:      n.handle,
-					priority:    n.priority - 1,
-					middlewares: n.middlewares,
+					path:             n.path[i:],
+					fullPath:         n.fullPath,
+					wildChild:        n.wildChild,
+					nType:            static,
+					indices:          n.indices,
+					children:         n.children,
+					handle:           n.handle,
+					priority:         n.priority - 1,
+					middlewares:      n.middlewares,
+					groupMiddlewares: n.groupMiddlewares,
+					appMiddlewares:   n.appMiddlewares,
 				}
 
 				// Update maxParams (max of all children)
@@ -174,6 +176,9 @@ func (n *Node) addRoute(path string, handle RouterHandle, m ...Middleware) (outn
 				n.path = path[:i]
 				n.handle = nil
 				n.wildChild = false
+				n.middlewares = nil
+				n.groupMiddlewares = nil
+				n.appMiddlewares = nil
 			}
 
 			// Make new node a child of this node

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,33 @@
 ## dotweb版本记录：
 
+####Version 1.7.15
+* tip: replace *HttpContext to Context interface，used to implementation custom Context in dotweb
+* feature: add ContextCreater func() Context & HttpServer.SetContextCreater
+* refactor: update *HttpContext to Context interface in HttpServer & Middleware & Request
+* refactor: add defaultContextCreater used to create Context with HttpContext when HttpServer.ServeHTTP
+* example code: example/main.go
+* How to use SetContextCreater:
+~~~
+// define
+type testContext struct {
+	dotweb.HttpContext
+	TestInfo string
+}
+
+func testContextCreater() dotweb.Context {
+	return &testContext{TestInfo:"Test"}
+}
+
+// set into dotweb
+app.HttpServer.SetContextCreater(testContextCreater)
+
+// use in router
+func OutputTestInfo(ctx dotweb.Context) error {
+	return ctx.WriteString(ctx.(*testContext).TestInfo)
+}
+~~~
+* 2021-01-24 18:00 at ShangHai
+
 #### Version 1.7.14
 * fix: fixed can not set redis maxIdle & maxActive when use redis session, fix for issue #236
 * refactor: add StoreConfig.MaxIdle & StoreConfig.MaxActive set redis maxIdle & maxActive

--- a/version.MD
+++ b/version.MD
@@ -12,7 +12,7 @@
 * refactor: add defaultContextCreater used to create Context with HttpContext when HttpServer.ServeHTTP
 * example code: example/main.go
 * How to use SetContextCreater:
-~~~
+~~~ go
 // define
 type testContext struct {
 	dotweb.HttpContext

--- a/version.MD
+++ b/version.MD
@@ -1,5 +1,10 @@
 ## dotweb版本记录：
 
+####Version 1.7.16
+* Bug fix: fix middleware chain misbehaving in netsed groups
+* Tips: for issue #234, thanks for @live's code
+* 2021-01-24 22:00 at ShangHai
+
 ####Version 1.7.15
 * tip: replace *HttpContext to Context interface，used to implementation custom Context in dotweb
 * feature: add ContextCreater func() Context & HttpServer.SetContextCreater


### PR DESCRIPTION
####Version 1.7.16
* Bug fix: fix middleware chain misbehaving in netsed groups
* Tips: for issue #234, thanks for @live's code
* Tips: replace *HttpContext to Context interface，used to implementation custom Context in dotweb
* feature: add ContextCreater func() Context & HttpServer.SetContextCreater
* refactor: update *HttpContext to Context interface in HttpServer & Middleware & Request
* refactor: add defaultContextCreater used to create Context with HttpContext when HttpServer.ServeHTTP
* example code: example/main.go
* How to use SetContextCreater:
~~~ go
// define
type testContext struct {
	dotweb.HttpContext
	TestInfo string
}

func testContextCreater() dotweb.Context {
	return &testContext{TestInfo:"Test"}
}

// set into dotweb
app.HttpServer.SetContextCreater(testContextCreater)

// use in router
func OutputTestInfo(ctx dotweb.Context) error {
	return ctx.WriteString(ctx.(*testContext).TestInfo)
}
~~~
* 2021-01-24 22:00 at ShangHai